### PR TITLE
Add End-to-End (E2E) Testing with Maestro for Navigation and Issue Reporting

### DIFF
--- a/app.json
+++ b/app.json
@@ -13,13 +13,15 @@
       "backgroundColor": "#ffffff"
     },
     "ios": {
-      "supportsTablet": true
+      "supportsTablet": true, 
+      "bundleIdentifier": "com.swent.leazy"
     },
     "android": {
       "adaptiveIcon": {
         "foregroundImage": "./assets/images/adaptive-icon.png",
         "backgroundColor": "#ffffff"
-      }
+      },
+      "package": "com.swent.leazy"
     },
     "web": {
       "bundler": "metro",

--- a/app/screens/SettingsScreen.tsx
+++ b/app/screens/SettingsScreen.tsx
@@ -11,7 +11,7 @@ export default function SettingsScreen() {
   return (
     <View style={styles.container}>
       {/* Custom Back Button at the top */}
-      <TouchableOpacity style={styles.backButton} onPress={() => navigation.goBack()}>
+      <TouchableOpacity testID='go-back-button' style={styles.backButton} onPress={() => navigation.goBack()}>
         <Ionicons name="arrow-back" size={24} color="black" />
         <Text style={styles.backButtonText}>Back</Text>
       </TouchableOpacity>
@@ -54,3 +54,4 @@ const styles = StyleSheet.create({
     color: 'black',
   },
 });
+

--- a/flow.yml
+++ b/flow.yml
@@ -1,0 +1,20 @@
+appId: "com.swent.leazy"
+---
+- launchApp
+
+- tapOn: "Go to Settings"
+
+- tapOn : 
+      id: "go-back-button"
+
+- tapOn:
+    point: "7%,6%"
+
+- tapOn: "Report"
+
+- tapOn: "Name the issue"
+- inputText: "Meastro test for e2e"
+
+- tapOn: "Description"
+- inputText: "This is a test for e2e"
+


### PR DESCRIPTION
This pull request introduces end-to-end (E2E) testing functionality using Maestro for the leazy app. The key focus is automating user flows such as navigating to the settings screen, going back, and submitting an issue report. A new YAML-based test flow (flow.yml) has been added, along with the necessary configurations in app.json and SettingsScreen.tsx for supporting Maestro's test automation.

Key changes:

Updated app.json with the Android and iOS identifiers required by Maestro.
Added test IDs to SettingsScreen.tsx components for easier element selection during test execution.
Created a new Maestro test flow (flow.yml) to automate navigation to the settings screen, going back, and submitting an issue report.
Added basic tests for interaction and text input within the app.
Maestro flow highlights:

Tests opening the app and navigating to the settings screen.
Tests interaction with the back button.
Simulates user input for the issue report with a predefined issue name and description.
This setup lays the foundation for more comprehensive automated testing, ensuring key app flows are stable and behave as expected.

Also, wrote a wiki on how to install Maestro and how it works for other people of the group [E2E with maestro](https://github.com/Swent-Fall-2024-team-10/leazy/wiki/End%E2%80%90To%E2%80%90End-Testing-with-Maestro)


Also here is a demo of the e2e testing script made

https://github.com/user-attachments/assets/0e5f14d0-fdc0-4b10-a21b-8540c20bfa32

