### PR TITLE
Reworked carousel for proper displaying of the images submitted

### DIFF
--- a/app/components/StatusDropdown.tsx
+++ b/app/components/StatusDropdown.tsx
@@ -31,6 +31,7 @@ const StatusDropdown: React.FC<StatusDropdownProps> = ({ value, setValue }) => {
         style={styles.dropdown}
         textStyle={styles.dropdownText}
         dropDownContainerStyle={styles.dropdownContainer}
+        listMode="SCROLLVIEW"
       />
     </View>
   );

--- a/app/screens/CapturedMediaScreen.tsx
+++ b/app/screens/CapturedMediaScreen.tsx
@@ -24,10 +24,32 @@ export default function CapturedMediaScreen() {
 
 const handleUpload = useCallback(async () => {
   try {
-    // Resize the image
+
+    // Define a type for the dimensions object
+    type ImageDimensions = { width: number; height: number };
+
+    // Step 1: Get the original dimensions of the image using a promise
+    const getImageDimensions = (uri: string): Promise<ImageDimensions> => {
+      return new Promise((resolve, reject) => {
+        Image.getSize(
+          uri,
+          (width, height) => resolve({ width, height }),
+          (error) => reject(error)
+        );
+      });
+    };
+
+    // Retrieve dimensions with the correct type
+    const { width, height } = await getImageDimensions(uri);
+
+    // Step 2: Calculate target dimensions (e.g., 50% of original)
+    const targetWidth = width * 0.5; // Adjust 0.5 to the desired percentage
+    const targetHeight = height * 0.5; // Adjust 0.5 to the desired percentage
+
+    // Step 3: Resize the image using ImageManipulator
     const resizedImage = await ImageManipulator.manipulateAsync(
       uri,
-      [{ resize: { width: 800, height: 600 } }], // Set target dimensions
+      [{ resize: { width: targetWidth, height: targetHeight } }],
       { compress: 0.8, format: ImageManipulator.SaveFormat.JPEG }
     );
 

--- a/app/screens/IssueDetailsScreen.tsx
+++ b/app/screens/IssueDetailsScreen.tsx
@@ -58,7 +58,6 @@ const IssueDetailsScreen: React.FC = () => {
   const openFullScreen = (index: number) => {
     if (issue) {
     setCurrentImageIndex(index);
-    setFullScreenMode(true);
 
     Image.getSize(issue.picture[index], (width, height) => {
       const screenWidth = Dimensions.get('window').width * 0.9;
@@ -78,6 +77,7 @@ const IssueDetailsScreen: React.FC = () => {
       }
 
       setFullImageDimensions({ width: finalWidth, height: finalHeight });
+      setFullScreenMode(true);
     });
   }
   };

--- a/app/screens/IssueDetailsScreen.tsx
+++ b/app/screens/IssueDetailsScreen.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { View, Text, StyleSheet, TouchableOpacity, Image, SafeAreaView, ScrollView, Dimensions } from 'react-native';
+import { View, Text, StyleSheet, TouchableOpacity, Image, SafeAreaView, ScrollView, Dimensions, Modal } from 'react-native';
 import { RouteProp, useNavigation, useRoute } from '@react-navigation/native';
 import { DrawerNavigationProp } from '@react-navigation/drawer';
 import { MaintenanceRequest, ReportStackParamList, RootStackParamList } from '../../types/types';
@@ -35,6 +35,9 @@ const IssueDetailsScreen: React.FC = () => {
     const [status, setStatus] = useState<MaintenanceRequest["requestStatus"]>('inProgress');
     const [description, setDescription] = useState('');  // State pour la description modifiable
     const [currentImageIndex, setCurrentImageIndex] = useState(0);
+    const [fullScreenMode, setFullScreenMode] = useState(false); // Track full-screen mode
+    const [fullImageDimensions, setFullImageDimensions] = useState({ width: 0, height: 0 });
+
 
     // Handle left arrow click
     const handlePreviousImage = () => {
@@ -49,6 +52,39 @@ const IssueDetailsScreen: React.FC = () => {
         setCurrentImageIndex((prevIndex) => (prevIndex === issue.picture.length - 1 ? 0 : prevIndex + 1));
       }
     };
+
+    // Open full-screen mode with the clicked image index
+  const openFullScreen = (index: number) => {
+    if (issue) {
+    setCurrentImageIndex(index);
+    setFullScreenMode(true);
+
+    Image.getSize(issue.picture[index], (width, height) => {
+      const screenWidth = Dimensions.get('window').width * 0.9;
+      const screenHeight = Dimensions.get('window').height * 0.9;
+
+      const aspectRatio = width / height;
+
+      let finalWidth, finalHeight;
+      if (width > height) {
+        // Landscape image
+        finalWidth = screenWidth;
+        finalHeight = screenWidth / aspectRatio;
+      } else {
+        // Portrait image
+        finalHeight = screenHeight;
+        finalWidth = screenHeight * aspectRatio;
+      }
+
+      setFullImageDimensions({ width: finalWidth, height: finalHeight });
+    });
+  }
+  };
+
+  // Close full-screen mode
+  const closeFullScreen = () => {
+    setFullScreenMode(false);
+  };
 
      // Récupérer l'issue depuis Firebase
   useEffect(() => {
@@ -91,7 +127,7 @@ const IssueDetailsScreen: React.FC = () => {
         <View style={styles.grayBackground}>
           <View style={styles.content}>
             <View style={styles.issueTitle}>
-              <Text style={styles.issueTitleText}>{issue.requestTitle}</Text>
+              <Text style={styles.issueTitleText}>Issue: {issue.requestTitle}</Text>
               <StatusBadge status={status} />
             </View>
 
@@ -103,19 +139,24 @@ const IssueDetailsScreen: React.FC = () => {
             
             <Text style={styles.sectionTitle}>Images submitted</Text>
             <View style={styles.imageCarouselContainer}>
-            <TouchableOpacity onPress={handlePreviousImage} style={styles.arrowButton}>
-              <Text style={styles.arrowText}>{'<'}</Text>
-            </TouchableOpacity>
 
-            <Image
-              source={{ uri: issue.picture[currentImageIndex] }}
-              style={styles.image}
-            />
+              <ScrollView
+                horizontal
+                showsHorizontalScrollIndicator={false}
+                contentContainerStyle={styles.scrollViewContainer}
+              >
+                {issue.picture.map((image, index) => (
+                  <TouchableOpacity key={index} onPress={() => openFullScreen(index)}>
+                    <Image key={index} source={{ uri: image }} style={styles.squareImage} />
+                  </TouchableOpacity>
 
-            <TouchableOpacity onPress={handleNextImage} style={styles.arrowButton}>
-              <Text style={styles.arrowText}>{'>'}</Text>
-            </TouchableOpacity>
-          </View>
+                ))}
+              </ScrollView>
+            </View>
+
+            <View style={styles.imagesTextView}>
+            <Text style={styles.imagesText}>Click on an image to expand it</Text>
+            </View>
 
             <View style={styles.descriptionContainer}>
               <Text style={styles.sectionTitle}>Description</Text>
@@ -131,6 +172,29 @@ const IssueDetailsScreen: React.FC = () => {
             <AdaptiveButton title = {'Close'} onPress = {handleClose}>
             </AdaptiveButton>
 
+            {/* Full-Screen Modal */}
+          <Modal visible={fullScreenMode} transparent={true} onRequestClose={closeFullScreen}>
+            <View style={styles.modalBackground}>
+              <TouchableOpacity onPress={closeFullScreen} style={styles.closeModalButton}>
+                <Text style={styles.closeModalText}>X</Text>
+              </TouchableOpacity>
+
+              <TouchableOpacity onPress={handlePreviousImage} style={[styles.arrowButton, styles.leftArrow]}>
+                <Text style={styles.arrowText}>{'<'}</Text>
+              </TouchableOpacity>
+
+              <Image
+                source={{ uri: issue.picture[currentImageIndex] }}
+                style={[styles.fullImage, fullImageDimensions]}
+                resizeMode="contain"
+              />
+
+              <TouchableOpacity onPress={handleNextImage} style={[styles.arrowButton, styles.rightArrow]}>
+                <Text style={styles.arrowText}>{'>'}</Text>
+              </TouchableOpacity>
+            </View>
+          </Modal>
+
           </View>
         </View>
     </Header>
@@ -138,6 +202,61 @@ const IssueDetailsScreen: React.FC = () => {
 };
 
 const styles = StyleSheet.create({
+  imagesTextView:{
+    justifyContent: 'center',
+    alignItems: 'center',
+    paddingBottom: 32,
+  },
+  imagesText:{
+    fontFamily: "Inter-Regular",
+  },
+  closeModalButton: {
+    position: 'absolute',
+    top: 40,
+    right: 20,
+    zIndex: 2,
+  },
+  closeModalText: {
+    color: 'white',
+    fontSize: 24,
+    fontWeight: 'bold',
+  },
+  modalBackground: {
+    flex: 1,
+    backgroundColor: 'rgba(0, 0, 0, 0.8)',
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  fullImage: {
+    borderRadius: 16,
+    borderColor: 'lightgrey',
+    borderWidth: 0.5,
+  },
+  imageCarouselContainer: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    marginBottom: 16,
+    position: 'relative',
+  },
+  scrollViewContainer: {
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+  squareImage: {
+    width: 150, // Square dimension
+    height: 150, // Square dimension
+    marginHorizontal: 5,
+    borderRadius: 8,
+    borderColor: 'lightgrey',
+    borderWidth: 0.5,
+  },
+  leftArrow: {
+    left: 5,
+  },
+  rightArrow: {
+    right: 5,
+  },
   grayBackground: {
     backgroundColor: '#F3F2F1',
     marginHorizontal: 10,
@@ -165,7 +284,7 @@ const styles = StyleSheet.create({
     marginBottom: 8,
     fontSize: 16,
     letterSpacing: 0.2,
-    fontFamily: "Inter-Regular",
+    fontFamily: "Inter-Bold",
   },
   image: {
     width: '100%',
@@ -230,19 +349,17 @@ const styles = StyleSheet.create({
   closeButtonContainer: {
     alignItems: 'center',
   },
-  imageCarouselContainer: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'center',
-    marginBottom: 16,
-  },
   arrowButton: {
-    padding: 10,
+    position: 'absolute',
+    top: '50%',
+    transform: [{ translateY: -12 }],
+    zIndex: 1,
+    padding: 8,
   },
   arrowText: {
     fontSize: 24,
     fontWeight: 'bold',
-    color: '#333',
+    color: 'white',
   },
 });
 

--- a/app/screens/IssueDetailsScreen.tsx
+++ b/app/screens/IssueDetailsScreen.tsx
@@ -9,6 +9,7 @@ import Header from '../components/Header';
 import StatusBadge from '../components/StatusBadge';
 import AdaptiveButton from '../components/AdaptiveButton';
 import { getMaintenanceRequest, updateMaintenanceRequest } from '@/firebase/firestore/firestore';
+import Spacer from '../components/Spacer';
 
 // portions of this code were generated with chatGPT as an AI assistant
 
@@ -125,7 +126,7 @@ const IssueDetailsScreen: React.FC = () => {
   return (
     <Header>
         <View style={styles.grayBackground}>
-          <View style={styles.content}>
+          <ScrollView style={styles.content} automaticallyAdjustKeyboardInsets = {true} showsVerticalScrollIndicator = {false}>
             <View style={styles.issueTitle}>
               <Text style={styles.issueTitleText}>Issue: {issue.requestTitle}</Text>
               <StatusBadge status={status} />
@@ -137,7 +138,7 @@ const IssueDetailsScreen: React.FC = () => {
             iconPosition= {'right'}
             ></AdaptiveButton>
             
-            <Text style={styles.sectionTitle}>Images submitted</Text>
+            <Text style={styles.sectionTitleImage}>Images submitted</Text>
             <View style={styles.imageCarouselContainer}>
 
               <ScrollView
@@ -194,8 +195,8 @@ const IssueDetailsScreen: React.FC = () => {
               </TouchableOpacity>
             </View>
           </Modal>
-
-          </View>
+          <Spacer height={20} />
+          </ScrollView>
         </View>
     </Header>
   );
@@ -209,6 +210,7 @@ const styles = StyleSheet.create({
   },
   imagesText:{
     fontFamily: "Inter-Regular",
+    fontSize: 10,
   },
   closeModalButton: {
     position: 'absolute',
@@ -258,10 +260,12 @@ const styles = StyleSheet.create({
     right: 5,
   },
   grayBackground: {
+    height: Dimensions.get('window').height * 0.8,
     backgroundColor: '#F3F2F1',
     marginHorizontal: 10,
     marginVertical: 12,
     borderRadius: 32,
+    overflow: 'hidden',
     // Add black border
     borderColor: 'light-grey',
     borderWidth: 0.5,
@@ -281,7 +285,8 @@ const styles = StyleSheet.create({
     marginBottom: 16,
   },
   issueTitleText: {
-    marginBottom: 8,
+    marginBottom: 20,
+    paddingLeft: 8,
     fontSize: 16,
     letterSpacing: 0.2,
     fontFamily: "Inter-Bold",
@@ -297,6 +302,7 @@ const styles = StyleSheet.create({
   },
   descriptionContainer: {
     marginBottom: 16,
+    marginTop: -8,
   },
   descriptionBox: {
     backgroundColor: 'white',
@@ -318,6 +324,12 @@ const styles = StyleSheet.create({
     fontSize: 16,
     fontWeight: '600',
     marginBottom: 8,
+  },
+  sectionTitleImage: {
+    fontSize: 16,
+    fontWeight: '600',
+    marginBottom: 8,
+    marginTop: 8,
   },
   descriptionText: {
     fontSize: 14,

--- a/app/screens/LandlordListIssuesScreen.tsx
+++ b/app/screens/LandlordListIssuesScreen.tsx
@@ -1,0 +1,288 @@
+import React, { useState, useEffect } from 'react';
+import { View, Text, ScrollView, StyleSheet, TouchableOpacity, Switch } from 'react-native';
+import { Feather } from '@expo/vector-icons';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import Header from '../components/Header';
+import { getLandlord, getResidence, getTenant, getMaintenanceRequest } from '../../firebase/firestore/firestore';
+import { MaintenanceRequest, Landlord, Residence, Tenant } from '../../types/types';
+import { RootStackParamList } from '../../types/types';
+import { useNavigation, NavigationProp } from '@react-navigation/native';
+import { getAuth } from 'firebase/auth';
+
+// portions of this code were generated with chatGPT as an AI assistant
+
+const LandlordListIssuesScreen: React.FC = () => {
+  const [showArchived, setShowArchived] = useState(false);
+  const [issues, setIssues] = useState<MaintenanceRequest[]>([]);
+  const [expandedResidences, setExpandedResidences] = useState<string[]>([]);
+  const [filterVisible, setFilterVisible] = useState(false); // Control the visibility of the filter
+  const [residences, setResidences] = useState<Residence[]>([]); // Store residence data
+  const [tenants, setTenants] = useState<{ [residenceId: string]: Tenant[] }>({}); // Store tenants data by residence
+
+  const auth = getAuth();
+  const currentUser = auth.currentUser;
+  const landlordId = currentUser ? currentUser.uid : null; // Fetch the landlord ID
+
+  useEffect(() => {
+    const fetchIssues = async () => {
+      try {
+        if (!landlordId) {
+            console.error("Landlord is not logged in");
+            return;
+          }
+  
+          // Fetch tenant data and maintenance requests for that tenant
+          const landlord: Landlord | null = await getLandlord(landlordId);
+
+        if (landlord && landlord.residenceIds.length > 0) {
+          const fetchedResidences: Residence[] = [];
+          const residenceTenants: { [residenceId: string]: Tenant[] } = {};
+
+          // Fetch each residence and its tenants
+          for (const residenceId of landlord.residenceIds) {
+            const residence: Residence | null = await getResidence(residenceId);
+
+            if (residence) {
+              fetchedResidences.push(residence);
+
+              // Fetch tenants for each residence
+              const tenantsForResidence = await Promise.all(
+                residence.tenantIds.map((tenantId) => getTenant(tenantId))
+              );
+
+              // Filter out any null tenants
+              residenceTenants[residenceId] = tenantsForResidence.filter(
+                (tenant): tenant is Tenant => tenant !== null
+              );
+            }
+          }
+
+          setResidences(fetchedResidences);
+          setTenants(residenceTenants);
+
+          // Fetch maintenance requests for each tenant
+          const allIssues: MaintenanceRequest[] = [];
+          for (const residenceId in residenceTenants) {
+            const tenants = residenceTenants[residenceId];
+            for (const tenant of tenants) {
+              const requests = await Promise.all(
+                tenant.maintenanceRequests.map((requestId) =>
+                  getMaintenanceRequest(requestId)
+                )
+              );
+              // Filter out null requests
+              const validRequests = requests.filter(
+                (request): request is MaintenanceRequest => request !== null
+              );
+              allIssues.push(...validRequests);
+            }
+          }
+
+          setIssues(allIssues);
+        }
+      } catch (error) {
+        console.error('Error fetching landlord data:', error);
+      }
+    };
+
+    fetchIssues();
+  }, []);
+
+  // Toggle the visibility of the filter section
+  const toggleFilter = () => {
+    setFilterVisible(!filterVisible);
+  };
+
+  // Toggle residence expansion
+  const toggleResidenceExpansion = (residenceId: string) => {
+    if (expandedResidences.includes(residenceId)) {
+      setExpandedResidences(expandedResidences.filter((id) => id !== residenceId));
+    } else {
+      setExpandedResidences([...expandedResidences, residenceId]);
+    }
+  };
+
+  // Filter the issues based on archived state
+  const filteredIssues = issues.filter(
+    (issue) => issue.requestStatus !== 'completed' || showArchived
+  );
+
+  return (
+    <View style={styles.container}>
+      <Header>
+        <ScrollView style={styles.scrollView}>
+          <View style={styles.titleContainer}>
+            <Text style={styles.title}>Maintenance issues</Text>
+          </View>
+
+          {/* Archived switch */}
+          <View style={styles.switchContainer}>
+            <Text>Archived issues</Text>
+            <Switch style={[{ marginLeft: 8 }, {marginRight: 48}, 
+                {marginBottom: 8}, {marginTop: 8}]}
+                value={showArchived} onValueChange={setShowArchived} />
+            {/* Filter button */}
+            <TouchableOpacity onPress={toggleFilter} style={styles.filterButton}>
+                <Feather name="filter" size={24} color="black" />
+                <Text style={styles.filterText}>Filter</Text>
+            </TouchableOpacity>
+          </View>
+
+          
+
+          {/* Expandable Filter Section */}
+          {filterVisible && (
+            <View style={styles.filterOptions}>
+              <Text>Filter by...</Text>
+              <Text>Status</Text>
+              <Text>Sort by...</Text>
+              {/* Add filter options as needed */}
+              <TouchableOpacity onPress={toggleFilter}>
+                <Text style={styles.applyButton}>Apply</Text>
+              </TouchableOpacity>
+            </View>
+          )}
+
+          {/* Residences and issues */}
+          <View style={styles.residenceList}>
+            {residences.map((residence) => (
+              <View key={residence.residenceId}>
+                <TouchableOpacity
+                  style={styles.residenceItem}
+                  onPress={() => toggleResidenceExpansion(residence.residenceId)}
+                >
+                  <Text style={styles.residenceText}>Residence {residence.street}</Text>
+                  <Feather
+                    name={expandedResidences.includes(residence.residenceId) ? 'chevron-up' : 'chevron-down'}
+                    size={24}
+                    color="black"
+                  />
+                </TouchableOpacity>
+
+                {/* If expanded, show the related issues */}
+                {expandedResidences.includes(residence.residenceId) && (
+                  <View style={styles.issueList}>
+                    {filteredIssues
+                      .filter((issue) => issue.residenceId === residence.residenceId)
+                      .map((issue) => (
+                        <View key={issue.requestID} style={styles.issueItem}>
+                          <Text>{issue.requestTitle}</Text>
+                          <View
+                            style={[
+                              styles.statusBadge,
+                              {
+                                backgroundColor:
+                                  issue.requestStatus === 'inProgress'
+                                    ? '#F39C12'
+                                    : issue.requestStatus === 'notStarted'
+                                    ? '#E74C3C'
+                                    : '#2ECC71',
+                              },
+                            ]}
+                          >
+                            <Text style={styles.statusText}>
+                              Status: {issue.requestStatus}
+                            </Text>
+                          </View>
+                        </View>
+                      ))}
+                  </View>
+                )}
+              </View>
+            ))}
+          </View>
+        </ScrollView>
+      </Header>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  titleContainer: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    alignSelf: 'center',
+  },
+  title: {
+    fontSize: 24,
+    fontWeight: 'bold',
+    color: '#2C3E50',
+    textAlign: 'center', 
+  },
+  switchContainer: {
+    flexDirection: 'row',
+    alignSelf: 'center',
+    alignItems: 'center',
+  },
+  filterButton: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    marginVertical: 10,
+  },
+  filterText: {
+    marginLeft: 8,
+    fontSize: 16,
+    color: '#2C3E50',
+  },
+  filterOptions: {
+    paddingHorizontal: 16,
+    paddingVertical: 10,
+    backgroundColor: '#f5f5f5',
+    borderRadius: 8,
+    marginBottom: 10,
+  },
+  applyButton: {
+    marginTop: 10,
+    textAlign: 'center',
+    color: '#2C3E50',
+    fontSize: 16,
+    fontWeight: 'bold',
+  },
+  residenceList: {
+    paddingHorizontal: 16,
+  },
+  residenceItem: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    backgroundColor: '#EDEDED',
+    borderRadius: 16,
+    padding: 16,
+    marginBottom: 12,
+  },
+  residenceText: {
+    fontSize: 18,
+    color: '#2C3E50',
+  },
+  issueList: {
+    paddingLeft: 16,
+  },
+  issueItem: {
+    backgroundColor: '#f9f9f9',
+    borderRadius: 8,
+    padding: 12,
+    marginBottom: 8,
+  },
+  statusBadge: {
+    borderRadius: 16,
+    paddingVertical: 5,
+    paddingHorizontal: 8,
+    alignSelf: 'flex-start',
+    marginTop: 8,
+  },
+  statusText: {
+    color: '#fff',
+    fontSize: 12,
+  },
+  scrollView: {
+    flex: 1,
+    paddingTop: 15,
+  },  
+});
+
+export default LandlordListIssuesScreen;

--- a/app/screens/LandlordListIssuesScreen.tsx
+++ b/app/screens/LandlordListIssuesScreen.tsx
@@ -106,7 +106,7 @@ const LandlordListIssuesScreen: React.FC = () => {
   const filteredIssues = issues.filter(
     (issue) => issue.requestStatus !== 'completed' || showArchived
   );
- 
+
   return (
     <View style={styles.container}>
       <Header>

--- a/app/screens/LandlordListIssuesScreen.tsx
+++ b/app/screens/LandlordListIssuesScreen.tsx
@@ -106,7 +106,7 @@ const LandlordListIssuesScreen: React.FC = () => {
   const filteredIssues = issues.filter(
     (issue) => issue.requestStatus !== 'completed' || showArchived
   );
-
+ 
   return (
     <View style={styles.container}>
       <Header>

--- a/app/screens/ReportScreen.tsx
+++ b/app/screens/ReportScreen.tsx
@@ -150,14 +150,16 @@ export default function ReportScreen() {
         
         <CameraButton onPress={handleAddPicture} />
 
-        <View style={styles.thumbnails}>
-          {pictureList.map((picture, index) => (
-            <View key={index} style={styles.thumbnailBox}>
-              <Image source={{ uri: picture }} style={styles.thumbnailImage} />
-            </View>
-          ))}
-        </View>
+        <ScrollView
+                horizontal
+                showsHorizontalScrollIndicator={false}
+              >
+                {pictureList.map((image, index) => (
+                    <Image key={index} source={{ uri: image }} style={styles.thumbnailImage} />
+                ))}
+              </ScrollView>
 
+              <Spacer height={20} ></Spacer>
         
         <InputField
           label="Which room is the issue in?"
@@ -208,7 +210,6 @@ export default function ReportScreen() {
           height={44}
           label="Submit"
         />
-        <Spacer height={250} />
       </ScrollView>
 
     </Header>
@@ -218,6 +219,7 @@ export default function ReportScreen() {
 const styles = StyleSheet.create({
 
   thumbnailImage: {
+    marginHorizontal: 5,
     width: 100,
     height: 100,
     borderRadius: 10,

--- a/firebase/firestore/firestore.ts
+++ b/firebase/firestore/firestore.ts
@@ -1,6 +1,6 @@
 // Import Firestore database instance and necessary Firestore functions.
 import { db } from "../firebase";
-import { setDoc, doc, getDoc, updateDoc, deleteDoc } from "firebase/firestore";
+import { setDoc, doc, getDoc, updateDoc, deleteDoc, query, collection, where } from "firebase/firestore";
 
 // Import type definitions used throughout the functions.
 import {
@@ -241,6 +241,20 @@ export async function getMaintenanceRequest(
   const docRef = doc(db, "maintenanceRequests", requestID);
   const docSnap = await getDoc(docRef);
   return docSnap.exists() ? (docSnap.data() as MaintenanceRequest) : null;
+}
+
+/**
+ * Returns a Firestore query for maintenance requests by tenantId.
+ * This query can be used with onSnapshot to listen for real-time updates.
+ * @param tenantId - The unique identifier of the tenant.
+ * @returns A Firestore query for the maintenance requests collection.
+ */
+export function getMaintenanceRequestsQuery(tenantId: string) {
+  // Construct a query based on the tenantId
+  return query(
+    collection(db, 'maintenanceRequests'),
+    where('tenantId', '==', tenantId)
+  );
 }
 
 /**


### PR DESCRIPTION
(To merge after my other PRs)
This PR introduces a new version of the carousel design for the images submitted in a MaintenanceRequest. It is available in two screens: when an issue is created, and when we expand its details.

Upon creation:
The images are displayed in squares, in a horizontal Scrollview. If no image is taken, the scrollview isn't visible. Below is a screen recording of the report screen:

https://github.com/user-attachments/assets/c8489918-bda1-4b09-865a-3daaed1d2941

In the issue's details;
The images are also visible in a ScrollView, with bigger sizes, and they are clickable. Upon click, the selected image will enter full mode, and we can navigate between full-screen images using left and right arrows. Below is a screen recording of the issue's details screen (I could not upload a longer video due to size limitations):

https://github.com/user-attachments/assets/4f48c1ce-2ebc-405f-bbfc-6def8b56d613

Also, some bug fixes: The gray background now has a fixed size relative to the screen's dimensions (in IssueDetailsScreen), and does not depend on its children anymore (it caused problems when the issue's description was too long, for example). The children are transformed into a ScrollView, and are adjusted so that they don't overflow their parent when scrolling up.
As creating a scrollView produced another error related with the nesting of the dropdown picker (which is also inherently a ScrollView), the latter was adjusted accordingly.

The last fix is to avoid displaying an image in full mode before having calculated its correct dimensions relative to the screen's height and width, which produced a strip containing the distorted image for a few seconds before going back to normal. Now it ensures having finished the computations before proceeding with the carousel display.
