### PR TITLE
Test/unit testing for report screen

### DIFF
--- a/app/__tests__/ReportScreen.test.tsx
+++ b/app/__tests__/ReportScreen.test.tsx
@@ -12,6 +12,9 @@ jest.mock('../../firebase/firebase', () => ({
   updateMaintenanceRequest: jest.fn(),
   addDoc: jest.fn(),
   collection: jest.fn(),
+  query: jest.fn(),
+  where: jest.fn(),
+  getDocs: jest.fn(),
   auth: {
     currentUser: { uid: 'user123' }, // Mock currentUser object
   },
@@ -56,9 +59,14 @@ describe('ReportScreen', () => {
   });
 
   it('should call handleSubmit on Submit button press', async () => {
-    const { getUser, getTenant, addDoc, updateTenant, updateMaintenanceRequest } = require('../../firebase/firebase');
+    const { getUser, getTenant, addDoc, updateTenant, updateMaintenanceRequest, query, where, getDocs } = require('../../firebase/firebase');
 
-    // Mock Firebase functions
+    // Mocking Firestore query and getDocs
+    query.mockReturnValue('mockQuery');
+    where.mockReturnValue('mockWhere');
+    getDocs.mockResolvedValue({ empty: false, docs: [] });
+
+    // Mocking Firebase functions
     getUser.mockResolvedValue({ user: { userUID: 'user123' }, userUID: 'user123' });
     getTenant.mockResolvedValue({ tenant: { userId: 'user123', apartmentId: 'apt123' }, tenantUID: 'tenant123' });
     addDoc.mockResolvedValue({ id: 'request123' });

--- a/app/__tests__/ReportScreen.test.tsx
+++ b/app/__tests__/ReportScreen.test.tsx
@@ -1,0 +1,125 @@
+import React from 'react';
+import { render, fireEvent, waitFor, screen } from '@testing-library/react-native';
+import ReportScreen from '../screens/issues_tenant/ReportScreen'; // Adjust import according to your file structure
+import { NavigationProp } from '@react-navigation/native';
+import { db, auth } from '@/firebase/firebase'; // Import the Firebase functions if needed
+
+// Mock necessary Firebase functions
+jest.mock('../../firebase/firestore/firestore', () => ({
+  getUser: jest.fn(),
+  getTenant: jest.fn(),
+  updateTenant: jest.fn(),
+  updateMaintenanceRequest: jest.fn(),
+}));
+
+jest.mock('firebase/firestore', () => ({
+  addDoc: jest.fn(),
+  collection: jest.fn(),
+}));
+
+jest.mock('../context/PictureContext', () => ({
+  usePictureContext: jest.fn(() => ({
+    pictureList: ['fakePic1', 'fakePic2'],
+    resetPictureList: jest.fn(),
+  })),
+}));
+
+jest.mock('@react-navigation/native', () => ({
+  useNavigation: jest.fn(),
+}));
+
+describe('ReportScreen', () => {
+  let navigation: NavigationProp<any>;
+
+  beforeEach(() => {
+    // Mock navigation prop
+    navigation = {
+      navigate: jest.fn(),
+    } as unknown as NavigationProp<any>;
+
+    jest.mock('@react-navigation/native', () => ({
+        useNavigation: jest.fn(),
+      }));
+
+    // Reset all mocks before each test
+    jest.clearAllMocks();
+  });
+
+  it('should render the ReportScreen and display form elements', () => {
+    render(<ReportScreen />);
+
+    // Check if input fields, buttons, and other UI elements are rendered
+    expect(screen.getByTestId('testIssueNameField')).toBeTruthy();
+    expect(screen.getByTestId('testRoomNameField')).toBeTruthy();
+    expect(screen.getByTestId('testDescriptionField')).toBeTruthy();
+    expect(screen.getByText('Submit')).toBeTruthy();
+  });
+
+  it('should call handleSubmit on Submit button press', async () => {
+    const mockGetUser = require('@/firebase/firestore/firestore').getUser;
+    const mockGetTenant = require('@/firebase/firestore/firestore').getTenant;
+    const mockAddDoc = require('firebase/firestore').addDoc;
+    const mockUpdateTenant = require('@/firebase/firestore/firestore').updateTenant;
+    const mockUpdateMaintenanceRequest = require('@/firebase/firestore/firestore').updateMaintenanceRequest;
+
+    mockGetUser.mockResolvedValue({ user: { userUID: 'user123' }, userUID: 'user123' });
+    mockGetTenant.mockResolvedValue({ tenant: { userId: 'user123', apartmentId: 'apt123' }, tenantUID: 'tenant123' });
+    mockAddDoc.mockResolvedValue({ id: 'request123' });
+    mockUpdateTenant.mockResolvedValue(true);
+    mockUpdateMaintenanceRequest.mockResolvedValue(true);
+
+    render(<ReportScreen />);
+
+    // Fill in the form
+    fireEvent.changeText(screen.getByTestId('testIssueNameField'), 'Leaky faucet');
+    fireEvent.changeText(screen.getByTestId('testRoomNameField'), 'Kitchen');
+    fireEvent.changeText(screen.getByTestId('testDescriptionField'), 'The faucet is leaking water.');
+
+    // Press the Submit button
+    fireEvent.press(screen.getByText('Submit'));
+
+    // Wait for the submission to complete
+    await waitFor(() => expect(mockAddDoc).toHaveBeenCalledTimes(1));
+    expect(mockGetUser).toHaveBeenCalledWith(auth.currentUser?.uid);
+    expect(mockGetTenant).toHaveBeenCalledTimes(1);
+    expect(mockAddDoc).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({
+      requestTitle: 'Leaky faucet',
+      requestDescription: 'The faucet is leaking water.',
+    }));
+    expect(mockUpdateTenant).toHaveBeenCalledTimes(1);
+    expect(mockUpdateMaintenanceRequest).toHaveBeenCalledTimes(1);
+    expect(navigation.navigate).toHaveBeenCalledWith('Issues');
+  });
+
+  it('should show an error alert if user or tenant is not found', async () => {
+    const mockGetUser = require('@/firebase/firestore/firestore').getUser;
+    const mockGetTenant = require('@/firebase/firestore/firestore').getTenant;
+
+    mockGetUser.mockResolvedValue(null); // Simulate user not found
+
+    render(<ReportScreen />);
+
+    // Fill in the form
+    fireEvent.changeText(screen.getByTestId('testIssueNameField'), 'Leaky faucet');
+    fireEvent.changeText(screen.getByTestId('testRoomNameField'), 'Kitchen');
+    fireEvent.changeText(screen.getByTestId('testDescriptionField'), 'The faucet is leaking water.');
+
+    // Press the Submit button
+    fireEvent.press(screen.getByText('Submit'));
+
+    // Wait for the alert to be called
+    await waitFor(() => expect(mockGetUser).toHaveBeenCalledTimes(1));
+
+    // Check for alert display (you can spy on the alert if you want)
+    expect(screen.getByText('Error')).toBeTruthy();
+    expect(screen.getByText('User not found')).toBeTruthy();
+  });
+
+  it('should navigate to "CameraScreen" when Camera button is pressed', () => {
+    render(<ReportScreen />);
+
+    fireEvent.press(screen.getByText('Please take a picture of the damage or situation if applicable'));
+
+    expect(navigation.navigate).toHaveBeenCalledWith('CameraScreen');
+  });
+});

--- a/app/components/Header.tsx
+++ b/app/components/Header.tsx
@@ -4,7 +4,7 @@ import { useNavigation } from '@react-navigation/native';
 import { DrawerNavigationProp } from '@react-navigation/drawer';
 import { RootStackParamList } from '../../types/types';
 import {Menu, User } from 'react-native-feather';
-import { Color } from '@/styles/styles';
+import { Color } from '../../styles/styles';
 // portions of this code were generated with chatGPT as an AI assistant
 
 // Get screen width and height

--- a/app/components/buttons/CameraButton.tsx
+++ b/app/components/buttons/CameraButton.tsx
@@ -1,7 +1,7 @@
-import { AntDesign } from "@expo/vector-icons";
 import React from "react";
 import { View, TouchableOpacity, StyleSheet, Text } from "react-native";
-import { Color, FontSizes } from "@/styles/styles";
+import { Color, FontSizes } from "../../../styles/styles";
+import { Icon } from "react-native-elements/dist/icons/Icon";
 //import DropShadow from "react-native-drop-shadow";
 
 interface CloseProps {
@@ -16,7 +16,7 @@ export default function CameraButton( { onPress } : CloseProps) {
 
                 <TouchableOpacity style={styles.cameraButton}
                     onPress={onPress}>
-                    <AntDesign name="camera" size={50} color="white" />
+                    <Icon name="camera" size={50} color="white" />
                 </TouchableOpacity>
 
             </View>

--- a/app/components/buttons/Close.tsx
+++ b/app/components/buttons/Close.tsx
@@ -1,7 +1,7 @@
-import { AntDesign } from "@expo/vector-icons";
 import React from "react";
 import { View, TouchableOpacity, StyleSheet, Text } from "react-native";
-import { Color } from "@/styles/styles";
+import { Color } from "../../../styles/styles";
+import Icon from "react-native-vector-icons/MaterialIcons";
 
 interface CloseProps {
     onPress: () => void;
@@ -14,7 +14,7 @@ export default function Close( { onPress } : CloseProps) {
                 onPress={onPress}
             >
                 <Text style={styles.text}>Close</Text>
-                <AntDesign name="down" style={styles.arrowDown} />
+                <Icon name="close" size={50} color="white" />
             </TouchableOpacity>
         </View>
     );

--- a/app/components/buttons/CloseConfirmation.tsx
+++ b/app/components/buttons/CloseConfirmation.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { Text, StyleSheet, View } from "react-native";
 import { Button } from "react-native-elements";
-import { Color, FontSizes } from "@/styles/styles";
+import { Color, FontSizes } from "../../../styles/styles";
 //import DropShadow from "react-native-drop-shadow";
 
 interface CloseConfirmationProps {

--- a/app/components/buttons/SubmitButton.tsx
+++ b/app/components/buttons/SubmitButton.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { StyleSheet, View, StyleProp, ViewStyle } from "react-native";
 import { Button } from "react-native-elements";
-import { Color, FontSizes } from "@/styles/styles";
+import { Color, FontSizes } from "../../../styles/styles";
 
 interface SubmitButtonProps {
   disabled: boolean;

--- a/app/components/forms/text_input.tsx
+++ b/app/components/forms/text_input.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { View, Text, TextInput, StyleSheet, StyleProp, ViewStyle } from "react-native";
-import { Color } from "@/styles/styles";
+import { Color } from "../../../styles/styles";
 
 interface InputFieldProps {
   label?: string;

--- a/app/context/__tests__/PictureContext.test.tsx
+++ b/app/context/__tests__/PictureContext.test.tsx
@@ -1,0 +1,75 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react-native';
+import { PictureProvider, usePictureContext } from '../PictureContext';
+import { Text, Button } from 'react-native';
+import '@testing-library/jest-native/extend-expect';
+
+describe('PictureContext in React Native', () => {
+  const TestComponent = () => {
+    const { pictureList, addPicture, resetPictureList, removePicture } = usePictureContext();
+
+    return (
+      <>
+        <Text testID='pictureList'>{JSON.stringify(pictureList)}</Text>
+        <Button testID='' title="Add Picture" onPress={() => addPicture('test1')} />
+        <Button title="Remove Picture" onPress={() => removePicture('test1')} />
+        <Button title="Reset List" onPress={() => resetPictureList()} />
+      </>
+    );
+  };
+
+  const setup = () => {
+    return render(
+      <PictureProvider>
+        <TestComponent />
+      </PictureProvider>
+    );
+  };
+
+  test('initializes with an empty pictureList', () => {
+    const { getByTestId } = setup();
+    expect(getByTestId('pictureList')).toHaveTextContent('[]');
+  });
+
+  test('adds a picture to pictureList', () => {
+    const { getByTestId, getByText } = setup();
+
+    fireEvent.press(getByText('Add Picture'));
+    expect(getByTestId('pictureList')).toHaveTextContent('["test1"]');
+  });
+
+  test('removes a picture from pictureList', () => {
+    const { getByTestId, getByText } = setup();
+
+    // Add picture first
+    fireEvent.press(getByText('Add Picture'));
+    expect(getByTestId('pictureList')).toHaveTextContent('["test1"]');
+
+    // Remove picture
+    fireEvent.press(getByText('Remove Picture'));
+    expect(getByTestId('pictureList')).toHaveTextContent('[]');
+  });
+
+  test('resets the pictureList', () => {
+    const { getByTestId, getByText } = setup();
+
+    // Add pictures
+    fireEvent.press(getByText('Add Picture'));
+    fireEvent.press(getByText('Add Picture')); // Add again
+    expect(getByTestId('pictureList')).toHaveTextContent('["test1","test1"]');
+
+    // Reset list
+    fireEvent.press(getByText('Reset List'));
+    expect(getByTestId('pictureList')).toHaveTextContent('[]');
+  });
+
+  test('throws error when usePictureContext is used outside PictureProvider', () => {
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    expect(() => render(<TestComponent />)).toThrow(
+      'Context used outside of a PictureProvider'
+    );
+
+    errorSpy.mockRestore();
+  });
+});

--- a/app/screens/issues_tenant/ReportScreen.tsx
+++ b/app/screens/issues_tenant/ReportScreen.tsx
@@ -1,27 +1,27 @@
 import React, { useState, useEffect } from "react";
 import { Text, StyleSheet, View, Alert, Image, Modal } from "react-native";
 import { ScrollView } from "react-native-gesture-handler";
-import InputField from "@/app/components/forms/text_input";
-import Spacer from "@/app/components/Spacer";
-import SubmitButton from "@/app/components/buttons/SubmitButton";
-import { Color } from "@/styles/styles";
-import Close from "@/app/components/buttons/Close";
+import InputField from "../../components/forms/text_input";
+import Spacer from "../../components/Spacer";
+import SubmitButton from "../../components/buttons/SubmitButton";
+import { Color } from "../../../styles/styles";
+import Close from "../../components/buttons/Close";
 import { NavigationProp, useNavigation } from "@react-navigation/native"; // Import NavigationProp
-import { ReportStackParamList } from "@/types/types"; // Import or define your navigation types
-import CameraButton from "@/app/components/buttons/CameraButton";
+import { ReportStackParamList } from "../../../types/types"; // Import or define your navigation types
+import CameraButton from "../../components/buttons/CameraButton";
 import BouncyCheckbox from "react-native-bouncy-checkbox";
-import CloseConfirmation from "@/app/components/buttons/CloseConfirmation";
+import CloseConfirmation from "../../components/buttons/CloseConfirmation";
 import { collection, addDoc } from "firebase/firestore"; // Import Firestore functions
-import { MaintenanceRequest } from "@/types/types";
-import { db, auth } from "@/firebase/firebase";
+import { MaintenanceRequest } from "../../../types/types";
+import { db, auth } from "../../../firebase/firebase";
 import {
   getTenant,
   updateMaintenanceRequest,
   updateTenant,
   getUser,
-} from "@/firebase/firestore/firestore";
-import Header from "@/app/components/Header";
-import { usePictureContext } from "@/app/context/PictureContext";
+} from "../../../firebase/firestore/firestore";
+import Header from "../../components/Header";
+import { usePictureContext } from "../../context/PictureContext";
 
 // portions of this code were generated with chatGPT as an AI assistant
 

--- a/app/utils/StatusHelper.ts
+++ b/app/utils/StatusHelper.ts
@@ -1,4 +1,4 @@
-import { Color } from '@/styles/styles';
+import { Color } from '../../styles/styles';
 
 export function getIssueStatusColor(status: string) {
     switch (status) {

--- a/app/utils/__tests__/statusHelper.test.ts
+++ b/app/utils/__tests__/statusHelper.test.ts
@@ -1,0 +1,42 @@
+import { getIssueStatusColor, getIssueStatusText } from '../StatusHelper';
+import { Color } from '../../../styles/styles';
+
+describe('getIssueStatusColor', () => {
+  test('returns Color.completed for status "completed"', () => {
+    expect(getIssueStatusColor('completed')).toBe(Color.completed);
+  });
+
+  test('returns Color.inProgress for status "inProgress"', () => {
+    expect(getIssueStatusColor('inProgress')).toBe(Color.inProgress);
+  });
+
+  test('returns Color.notStarted for status "notStarted"', () => {
+    expect(getIssueStatusColor('notStarted')).toBe(Color.notStarted);
+  });
+
+  test('returns Color.default for unknown status', () => {
+    expect(getIssueStatusColor('unknown')).toBe(Color.default);
+  });
+});
+
+describe('getIssueStatusText', () => {
+  test('returns "Completed" for status "completed"', () => {
+    expect(getIssueStatusText('completed')).toBe('Completed');
+  });
+
+  test('returns "In Progress" for status "inProgress"', () => {
+    expect(getIssueStatusText('inProgress')).toBe('In Progress');
+  });
+
+  test('returns "Not Started" for status "notStarted"', () => {
+    expect(getIssueStatusText('notStarted')).toBe('Not Started');
+  });
+
+  test('returns "Rejected" for status "rejected"', () => {
+    expect(getIssueStatusText('rejected')).toBe('Rejected');
+  });
+
+  test('returns "Not Started" for unknown status', () => {
+    expect(getIssueStatusText('unknown')).toBe('Not Started');
+  });
+});

--- a/firebase/firebase.ts
+++ b/firebase/firebase.ts
@@ -9,8 +9,6 @@ import { setLogLevel } from "firebase/firestore";
 // https://firebase.google.com/docs/web/setup#available-libraries
 
 // Enable logs
-setLogLevel("debug");
-
 // For Firebase JS SDK v7.20.0 and later, measurementId is optional
 const firebaseConfig = {
   apiKey: "AIzaSyA7aViCzGhq5Q6Qxsl0EtVyTPl-eShdZdA",

--- a/firebase/firestore/firestore.ts
+++ b/firebase/firestore/firestore.ts
@@ -1,5 +1,5 @@
 // Import Firestore database instance and necessary Firestore functions.
-import { db, auth } from "@/firebase/firebase";
+import { db, auth } from "../../firebase/firebase";
 import {
   setDoc,
   doc,

--- a/jest/jest.config.js
+++ b/jest/jest.config.js
@@ -4,8 +4,12 @@ module.exports = {
     moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json', 'node'],
     transform: {
       '^.+\\.(ts|tsx)$': 'ts-jest',
+      '^.+\\.js$': 'babel-jest',
     },
     transformIgnorePatterns: [
-      'node_modules/(?!(firebase|@firebase)/)',
+      'node_modules/(?!(firebase|@firebase|react-native-elements|@react-native|react-native|react-native-gesture-handler|react-native-reanimated|expo|react-native-size-matters)/)',
     ],
+    moduleNameMapper: {
+      '^@/(.*)$': '<rootDir>/src/$1',  // Adjust the path according to your project structure
+    },
   };

--- a/jest/setup.js
+++ b/jest/setup.js
@@ -16,3 +16,30 @@ jest.mock('react-native-reanimated', () => {
 
 // Silence the warning: Animated: `useNativeDriver` is not supported because the native animated module is missing
 jest.mock('react-native/Libraries/Animated/NativeAnimatedHelper');
+
+jest.mock('@react-native-async-storage/async-storage', () =>
+  require('@react-native-async-storage/async-storage/jest/async-storage-mock')
+);
+
+// Mock Firebase functions in jest.setup.ts or directly in the test file
+jest.mock('firebase/app', () => ({
+  initializeApp: jest.fn(),
+}));
+
+jest.mock('firebase/firestore', () => ({
+  getFirestore: jest.fn(),
+  collection: jest.fn(),
+  addDoc: jest.fn(),
+  query: jest.fn(),
+  getDocs: jest.fn(),
+}));
+
+jest.mock('firebase/auth', () => ({
+  initializeAuth: jest.fn(),
+  getAuth: jest.fn(),
+}));
+
+jest.mock('@react-native-async-storage/async-storage', () => ({
+  getItem: jest.fn(),
+  setItem: jest.fn(),
+}));

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "expo-crypto": "~13.0.2",
         "expo-dev-client": "~4.0.28",
         "expo-font": "~12.0.9",
-        "expo-image-manipulator": "~12.0.5",
+        "expo-image-manipulator": "^12.0.5",
         "expo-linking": "~6.3.1",
         "expo-media-library": "^16.0.5",
         "expo-router": "~3.5.23",
@@ -5149,6 +5149,7 @@
       "version": "1.24.0",
       "resolved": "https://registry.npmjs.org/@react-native-async-storage/async-storage/-/async-storage-1.24.0.tgz",
       "integrity": "sha512-W4/vbwUOYOjco0x3toB8QCr7EjIP6nE9G7o8PMguvvjYT5Awg09lyV4enACRx4s++PPulBiBSjL0KTFx2u0Z/g==",
+      "license": "MIT",
       "dependencies": {
         "merge-options": "^3.0.4"
       },

--- a/package.json
+++ b/package.json
@@ -21,10 +21,11 @@
       "./jest/setup.js"
     ],
     "transform": {
-      "^.+\\.(js|jsx|ts|tsx)$": "babel-jest"
+      "^.+\\.(jsx|ts|tsx)$": "<rootDir>/node_modules/babel-jest",
+      "^.+\\.js$": "<rootDir>/node_modules/react-native/jest/preprocessor.js"
     },
     "transformIgnorePatterns": [
-      "node_modules/(?!(@react-native|react-native|@react-navigation|react-native-reanimated|react-native-gesture-handler|expo-modules-core|expo|@expo/vector-icons|@react-native/polyfills|@firebase|firebase)/)"
+      "node_modules/(?!(@react-native|react-native|@react-navigation|react-native-reanimated|react-native-gesture-handler|expo-modules-core|expo|@expo/vector-icons|@react-native/polyfills|@firebase|firebase|react-native-elements)/)"
     ],
     "testRegex": "(/__tests__/.*|(\\.|/)(test|spec))\\.[jt]sx?$",
     "moduleFileExtensions": [
@@ -43,7 +44,10 @@
       "!**/babel.config.js",
       "!**/expo-env.d.ts",
       "!**/.expo/**"
-    ]
+    ],
+    "moduleNameMapper": {
+      "^@/(.*)$": "<rootDir>/$1"
+    }
   },
   "dependencies": {
     "@expo/ngrok": "^4.1.0",
@@ -87,19 +91,19 @@
     "react-native-feather": "^1.1.2",
     "react-native-gesture-handler": "^2.20.0",
     "react-native-gifted-chat": "^2.6.4",
+    "react-native-reanimated": "~3.10.1",
     "react-native-safe-area-context": "^4.11.0",
     "react-native-screens": "^3.34.0",
     "react-native-svg": "^15.7.1",
     "react-native-vector-icons": "^10.2.0",
-    "react-native-web": "~0.19.10",
-    "react-native-reanimated": "~3.10.1"
+    "react-native-web": "~0.19.10"
   },
   "devDependencies": {
     "@babel/core": "^7.25.8",
     "@babel/plugin-transform-private-methods": "^7.25.7",
-    "@babel/preset-env": "^7.25.8",
+    "@babel/preset-env": "^7.26.0",
     "@babel/preset-modules": "^0.1.6",
-    "@babel/preset-react": "^7.25.7",
+    "@babel/preset-react": "^7.25.9",
     "@babel/preset-typescript": "^7.25.7",
     "@testing-library/dom": "^10.4.0",
     "@testing-library/jest-dom": "^6.6.1",
@@ -107,12 +111,13 @@
     "@testing-library/react-native": "^12.7.2",
     "@types/jest": "^29.5.13",
     "@types/react": "~18.2.45",
+    "@types/react-navigation": "^3.0.8",
     "@types/react-test-renderer": "^18.0.7",
     "babel-jest": "^29.7.0",
     "jest": "^29.7.0",
     "jest-expo": "~51.0.3",
     "jest-mock": "^29.7.0",
-    "metro-react-native-babel-preset": "^0.7&7.0",
+    "metro-react-native-babel-preset": "^0.77.0",
     "react-test-renderer": "18.2.0",
     "ts-jest": "^29.2.5",
     "typescript": "~5.3.3"

--- a/package.json
+++ b/package.json
@@ -21,11 +21,10 @@
       "./jest/setup.js"
     ],
     "transform": {
-      "^.+\\.(jsx|ts|tsx)$": "<rootDir>/node_modules/babel-jest",
-      "^.+\\.js$": "<rootDir>/node_modules/react-native/jest/preprocessor.js"
+      "^.+\\.(js|jsx|ts|tsx)$": "babel-jest"
     },
     "transformIgnorePatterns": [
-      "node_modules/(?!(@react-native|react-native|@react-navigation|react-native-reanimated|react-native-gesture-handler|expo-modules-core|expo|@expo/vector-icons|@react-native/polyfills|@firebase|firebase|react-native-elements)/)"
+      "node_modules/(?!(@react-native|react-native|@react-navigation|react-native-reanimated|react-native-gesture-handler|expo-modules-core|expo|@expo/vector-icons|@react-native/polyfills|@firebase|firebase|react-native-elements|react-native-size-matters|react-native-ratings|expo-font|react-native-vector-icons|react-native-bouncy-checkbox|react-native-feather)/)"
     ],
     "testRegex": "(/__tests__/.*|(\\.|/)(test|spec))\\.[jt]sx?$",
     "moduleFileExtensions": [
@@ -44,10 +43,7 @@
       "!**/babel.config.js",
       "!**/expo-env.d.ts",
       "!**/.expo/**"
-    ],
-    "moduleNameMapper": {
-      "^@/(.*)$": "<rootDir>/$1"
-    }
+    ]
   },
   "dependencies": {
     "@expo/ngrok": "^4.1.0",
@@ -91,19 +87,19 @@
     "react-native-feather": "^1.1.2",
     "react-native-gesture-handler": "^2.20.0",
     "react-native-gifted-chat": "^2.6.4",
-    "react-native-reanimated": "~3.10.1",
     "react-native-safe-area-context": "^4.11.0",
     "react-native-screens": "^3.34.0",
     "react-native-svg": "^15.7.1",
     "react-native-vector-icons": "^10.2.0",
-    "react-native-web": "~0.19.10"
+    "react-native-web": "~0.19.10",
+    "react-native-reanimated": "~3.10.1"
   },
   "devDependencies": {
     "@babel/core": "^7.25.8",
     "@babel/plugin-transform-private-methods": "^7.25.7",
-    "@babel/preset-env": "^7.26.0",
+    "@babel/preset-env": "^7.25.8",
     "@babel/preset-modules": "^0.1.6",
-    "@babel/preset-react": "^7.25.9",
+    "@babel/preset-react": "^7.25.7",
     "@babel/preset-typescript": "^7.25.7",
     "@testing-library/dom": "^10.4.0",
     "@testing-library/jest-dom": "^6.6.1",
@@ -111,7 +107,6 @@
     "@testing-library/react-native": "^12.7.2",
     "@types/jest": "^29.5.13",
     "@types/react": "~18.2.45",
-    "@types/react-navigation": "^3.0.8",
     "@types/react-test-renderer": "^18.0.7",
     "babel-jest": "^29.7.0",
     "jest": "^29.7.0",


### PR DESCRIPTION
This PR adds tests for the ReportScreen and includes unit tests for two features: the context management and a utility function that retrieves the correct color code based on the given status.

Although I haven't reached 80% coverage for the ReportScreen yet, as discussed in the Telegram group, Baudoin or someone else could work on reaching that threshold since I won’t have enough time due to the stochastic models midterm.

Merging this PR will allow someone else  to create a follow-up PR for the additional work he will contribute, ensuring he receives credit for his contribution.