### PR TITLE
Change User type name  into TUser type name

### DIFF
--- a/app/screens/auth/SignUpScreen.tsx
+++ b/app/screens/auth/SignUpScreen.tsx
@@ -10,7 +10,7 @@ import { Color, FontSizes, LayoutPadding, appStyles, ButtonDimensions } from '@/
 import { Ionicons } from '@expo/vector-icons';
 import SubmitButton from '@/app/components/buttons/SubmitButton';
 import { createTenant, createUser } from '@/firebase/firestore/firestore';
-import { User, Tenant, RootStackParamList, AuthStackParamList} from '@/types/types';
+import { TUser, Tenant, RootStackParamList, AuthStackParamList} from '@/types/types';
 import { TenantFormScreen } from '../tenant/';
 
 interface FormErrors {
@@ -64,7 +64,7 @@ export default function SignUpScreen() {
         if (userType === UserType.LANDLORD) {
 
           if (user.providerData[0].email != null) {
-          const newUser: User = {
+          const newUser: TUser = {
             uid: user.uid,
             type: "landlord",
             name: "",
@@ -87,7 +87,7 @@ export default function SignUpScreen() {
         } else if (userType === UserType.TENANT) {
             console.log("User signed up:", user);
             if (user.providerData[0].email != null) {
-            const newUser: User = {
+            const newUser: TUser = {
               uid: user.uid,
               type: "tenant",
               name: "",

--- a/firebase/firestore/firestore.ts
+++ b/firebase/firestore/firestore.ts
@@ -16,7 +16,7 @@ import {
 
 // Import type definitions used throughout the functions.
 import {
-  User,
+  TUser,
   Landlord,
   Tenant,
   Residence,
@@ -34,7 +34,7 @@ import { setLogLevel } from "firebase/firestore";
  * Creates a new user document in Firestore.
  * @param user - The user object to be added to the 'users' collection.
  */
-export async function createUser(user: User): Promise<string> {
+export async function createUser(user: TUser): Promise<string> {
   const usersCollectionRef = collection(db, "users");
   const docRef = await addDoc(usersCollectionRef, user);
   return docRef.id;
@@ -47,14 +47,14 @@ export async function createUser(user: User): Promise<string> {
  */
 export async function getUser(
   uid: string
-): Promise<{ user: User; userUID: string } | null> {
+): Promise<{ user: TUser; userUID: string } | null> {
   const usersRef = collection(db, "users");
   const q = query(usersRef, where("uid", "==", uid));
   const querySnapshot = await getDocs(q);
 
   if (!querySnapshot.empty) {
     const doc = querySnapshot.docs[0]; // Assume `uid` is unique, so take the first result
-    return { user: doc.data() as User, userUID: doc.id };
+    return { user: doc.data() as TUser, userUID: doc.id };
   } else {
     return null;
   }
@@ -65,7 +65,7 @@ export async function getUser(
  * @param uid - The unique identifier of the user to update.
  * @param user - The partial user data to update.
  */
-export async function updateUser(uid: string, user: Partial<User>) {
+export async function updateUser(uid: string, user: Partial<TUser>) {
   const docRef = doc(db, "users", uid);
   await updateDoc(docRef, user);
 }

--- a/types/types.ts
+++ b/types/types.ts
@@ -42,7 +42,7 @@ declare type TTenantData = {};
 declare type TLandlordData = {};
 
 // Define types for firestore
-export type User = {
+export type TUser = {
   uid: string; // uid of the user for authentication
   type: "tenant" | "landlord";
   name: string;

--- a/types/types.ts
+++ b/types/types.ts
@@ -38,9 +38,6 @@ export type ReportStackParamList = {
   };
 };
 
-declare type TTenantData = {};
-declare type TLandlordData = {};
-
 // Define types for firestore
 export type TUser = {
   uid: string; // uid of the user for authentication


### PR DESCRIPTION
### Refactoring: User into TUser

This PR aims to fix a confusion between the User interface proposed by firebase auth and User type we created to store a User in firestore.

I also removed TTenantData and TLandlordData since it's not used 

