### PR TITLE
Update Sonarcloud to ignore test files

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -5,3 +5,5 @@ sonar.javascript.lcov.reportPaths=coverage/lcov.info
 sonar.projectKey=Swent-Fall-2024-team-10_leazy
 sonar.organization=swent-fall-2024-team-10
 sonar.sources=app
+sonar.exclusions=app/__tests__/**
+sonar.test=app/__tests__/


### PR DESCRIPTION
This is a hotfix that prevents Sonarcloud from analyzing tests making it analyze source code only.