### PR TITLE
Add street no field to the ResidenceCreationScreen

### DIFF
--- a/app/__tests__/ResidenceCreationScreen.test.tsx
+++ b/app/__tests__/ResidenceCreationScreen.test.tsx
@@ -6,7 +6,7 @@ import * as FileSystem from 'expo-file-system';
 import * as XLSX from 'xlsx';
 import ResidenceCreationScreen from '../screens/landlord/ResidenceCreationScreen';
 
-// Navigation mock
+// Mock navigation
 const mockNavigate = jest.fn();
 jest.mock('@react-navigation/native', () => ({
   ...jest.requireActual('@react-navigation/native'),
@@ -15,14 +15,10 @@ jest.mock('@react-navigation/native', () => ({
   }),
 }));
 
-// Mock custom components
+// Mock components
 jest.mock('../components/Header', () => 'MockHeader');
-
 jest.mock('../components/CustomTextField', () => 'MockCustomTextField');
-
 jest.mock('../components/CustomButton', () => 'MockCustomButton');
-
-// Mock external components
 jest.mock('@expo/vector-icons', () => ({
   Ionicons: 'MockedIonicons',
 }));
@@ -37,27 +33,35 @@ jest.mock('expo-file-system', () => ({
   makeDirectoryAsync: jest.fn(),
   copyAsync: jest.fn(),
   readAsStringAsync: jest.fn(),
-  EncodingType: {
-    Base64: 'base64',
-  },
+  EncodingType: { Base64: 'base64' },
 }));
 
 jest.mock('xlsx', () => ({
   read: jest.fn(() => ({
     SheetNames: ['Sheet1'],
-    Sheets: {
-      Sheet1: {}
-    }
+    Sheets: { Sheet1: {} }
   })),
   utils: {
     sheet_to_json: jest.fn(() => [['Header'], ['Apt1'], ['Apt2']])
   }
 }));
 
-// Mock Alert
 jest.spyOn(Alert, 'alert');
 
 describe('ResidenceCreationScreen', () => {
+  const mockValidFormData = {
+    'residence-name': 'Test Residence',
+    'email': 'test@example.com',
+    'address': '123 Test St',
+    'number': '42',
+    'zip-code': '12345',
+    'city': 'Test City',
+    'province-state': 'Test State',
+    'country': 'Test Country',
+    'description': 'Test Description',
+    'website': 'https://example.com'
+  };
+
   beforeEach(() => {
     jest.clearAllMocks();
     (FileSystem.makeDirectoryAsync as jest.Mock).mockResolvedValue(undefined);
@@ -65,46 +69,121 @@ describe('ResidenceCreationScreen', () => {
     (FileSystem.readAsStringAsync as jest.Mock).mockResolvedValue('mock-base64-content');
   });
 
-  describe('Form Input Tests', () => {
-    it('should update form fields when user types', () => {
+  describe('Rendering', () => {
+    it('renders all form fields', () => {
       const { getByTestId } = render(<ResidenceCreationScreen />);
+      
+      Object.keys(mockValidFormData).forEach(fieldId => {
+        expect(getByTestId(fieldId)).toBeTruthy();
+      });
+      expect(getByTestId('next-button')).toBeTruthy();
+    });
 
-      const fields = [
-        { id: 'residence-name', value: 'Test Residence' },
-        { id: 'email', value: 'test@example.com' },
-        { id: 'website', value: 'https://test.com' }
-      ];
+    it('renders upload buttons', () => {
+      const { getByText } = render(<ResidenceCreationScreen />);
+      
+      expect(getByText('List of Apartments (.xlsx)')).toBeTruthy();
+      expect(getByText('Proof of Ownership')).toBeTruthy();
+      expect(getByText('Pictures of residence')).toBeTruthy();
+    });
+  });
 
-      fields.forEach(({ id, value }) => {
-        const input = getByTestId(id);
+  describe('Form Input Handling', () => {
+    it('updates form fields on user input', () => {
+      const { getByTestId } = render(<ResidenceCreationScreen />);
+      
+      Object.entries(mockValidFormData).forEach(([fieldId, value]) => {
+        const input = getByTestId(fieldId);
         fireEvent.changeText(input, value);
+        expect(input.props.value).toBe(value);
+      });
+    });
+
+    it('handles numeric input correctly', () => {
+      const { getByTestId } = render(<ResidenceCreationScreen />);
+      const numberInput = getByTestId('number');
+      
+      fireEvent.changeText(numberInput, '42');
+      expect(numberInput.props.value).toBe('42');
+      
+      fireEvent.changeText(numberInput, 'abc');
+      expect(numberInput.props.keyboardType).toBe('numeric');
+    });
+  });
+
+  describe('Validation', () => {
+    it('validates email format', async () => {
+      const { getByTestId } = render(<ResidenceCreationScreen />);
+      
+      fireEvent.changeText(getByTestId('email'), 'invalid-email');
+      fireEvent.press(getByTestId('next-button'));
+      
+      await waitFor(() => {
+        expect(mockNavigate).not.toHaveBeenCalled();
+      });
+    });
+
+    it('validates website format', async () => {
+      const { getByTestId } = render(<ResidenceCreationScreen />);
+      
+      fireEvent.changeText(getByTestId('website'), 'invalid-url');
+      fireEvent.press(getByTestId('next-button'));
+      
+      await waitFor(() => {
+        expect(mockNavigate).not.toHaveBeenCalled();
+      });
+    });
+
+    it('accepts valid form submission', async () => {
+      const { getByTestId } = render(<ResidenceCreationScreen />);
+      
+      Object.entries(mockValidFormData).forEach(([fieldId, value]) => {
+        fireEvent.changeText(getByTestId(fieldId), value);
+      });
+      
+      fireEvent.press(getByTestId('next-button'));
+      
+      await waitFor(() => {
+        expect(mockNavigate).toHaveBeenCalledWith('ResidenceList');
       });
     });
   });
 
-  describe('File Upload Tests', () => {
-    beforeEach(() => {
-      (DocumentPicker.getDocumentAsync as jest.Mock).mockClear();
-    });
-
-    it('should handle excel file upload', async () => {
-      const mockExcelFile = {
+  describe('File Upload Handling', () => {
+    it('handles excel file upload', async () => {
+      const mockFile = {
         canceled: false,
         assets: [{
           name: 'test.xlsx',
           uri: 'file:///test.xlsx'
         }]
       };
-      
-      (DocumentPicker.getDocumentAsync as jest.Mock).mockResolvedValueOnce(mockExcelFile);
+      (DocumentPicker.getDocumentAsync as jest.Mock).mockResolvedValueOnce(mockFile);
 
       const { getByTestId, getByText } = render(<ResidenceCreationScreen />);
-      
-      // Set residence name first
       fireEvent.changeText(getByTestId('residence-name'), 'Test Residence');
-      
-      const uploadButton = getByText('List of Apartments (.xlsx)');
-      fireEvent.press(uploadButton);
+      fireEvent.press(getByText('List of Apartments (.xlsx)'));
+
+      await waitFor(() => {
+        expect(DocumentPicker.getDocumentAsync).toHaveBeenCalled();
+        expect(FileSystem.copyAsync).toHaveBeenCalled();
+        expect(FileSystem.readAsStringAsync).toHaveBeenCalled();
+      });
+    });
+
+    it('handles PDF upload', async () => {
+      const mockFile = {
+        canceled: false,
+        assets: [{
+          name: 'test.pdf',
+          uri: 'file:///test.pdf'
+        }]
+      };
+      (DocumentPicker.getDocumentAsync as jest.Mock).mockResolvedValueOnce(mockFile);
+
+      const { getByTestId, getByText } = render(<ResidenceCreationScreen />);
+      fireEvent.changeText(getByTestId('residence-name'), 'Test Residence');
+      fireEvent.press(getByText('Proof of Ownership'));
 
       await waitFor(() => {
         expect(DocumentPicker.getDocumentAsync).toHaveBeenCalled();
@@ -112,13 +191,31 @@ describe('ResidenceCreationScreen', () => {
       });
     });
 
-    it('should handle file upload cancellation', async () => {
-      const mockCancelledUpload = {
+    it('handles image upload', async () => {
+      const mockFile = {
+        canceled: false,
+        assets: [{
+          name: 'test.jpg',
+          uri: 'file:///test.jpg'
+        }]
+      };
+      (DocumentPicker.getDocumentAsync as jest.Mock).mockResolvedValueOnce(mockFile);
+
+      const { getByTestId, getByText } = render(<ResidenceCreationScreen />);
+      fireEvent.changeText(getByTestId('residence-name'), 'Test Residence');
+      fireEvent.press(getByText('Pictures of residence'));
+
+      await waitFor(() => {
+        expect(DocumentPicker.getDocumentAsync).toHaveBeenCalled();
+        expect(FileSystem.copyAsync).toHaveBeenCalled();
+      });
+    });
+
+    it('handles upload cancellation', async () => {
+      (DocumentPicker.getDocumentAsync as jest.Mock).mockResolvedValueOnce({
         canceled: true,
         assets: null
-      };
-
-      (DocumentPicker.getDocumentAsync as jest.Mock).mockResolvedValueOnce(mockCancelledUpload);
+      });
 
       const { getByText } = render(<ResidenceCreationScreen />);
       fireEvent.press(getByText('List of Apartments (.xlsx)'));
@@ -127,62 +224,47 @@ describe('ResidenceCreationScreen', () => {
         expect(FileSystem.copyAsync).not.toHaveBeenCalled();
       });
     });
-  });
 
-  describe('Form Validation Tests', () => {
-    it('should show email validation error', async () => {
-      const { getByTestId } = render(<ResidenceCreationScreen />);
+    it('validates file extensions', async () => {
+      const mockFile = {
+        canceled: false,
+        assets: [{
+          name: 'test.txt',
+          uri: 'file:///test.txt'
+        }]
+      };
+      (DocumentPicker.getDocumentAsync as jest.Mock).mockResolvedValueOnce(mockFile);
 
-      fireEvent.changeText(getByTestId('email'), 'invalid-email');
-      fireEvent.press(getByTestId('next-button'));
-
-      await waitFor(() => {
-        expect(mockNavigate).not.toHaveBeenCalled();
-      });
-    });
-
-    it('should validate website format', async () => {
-      const { getByTestId } = render(<ResidenceCreationScreen />);
-
-      fireEvent.changeText(getByTestId('website'), 'invalid-url');
-      fireEvent.press(getByTestId('next-button'));
-
-      await waitFor(() => {
-        expect(mockNavigate).not.toHaveBeenCalled();
-      });
-    });
-  });
-
-  describe('Form Submission Tests', () => {
-    it('should navigate to ResidenceList after successful submission', async () => {
-      const { getByTestId } = render(<ResidenceCreationScreen />);
-
-      // Fill required fields
+      const { getByTestId, getByText } = render(<ResidenceCreationScreen />);
       fireEvent.changeText(getByTestId('residence-name'), 'Test Residence');
-      fireEvent.changeText(getByTestId('email'), 'test@example.com');
-      fireEvent.changeText(getByTestId('website'), 'https://example.com');
-
-      fireEvent.press(getByTestId('next-button'));
+      fireEvent.press(getByText('List of Apartments (.xlsx)'));
 
       await waitFor(() => {
-        expect(mockNavigate).toHaveBeenCalledWith('ResidenceList');
+        expect(Alert.alert).toHaveBeenCalledWith(
+          'Invalid file type',
+          expect.any(String)
+        );
       });
     });
-  });
 
-  describe('Component Rendering Tests', () => {
-    it('should render all required form elements', () => {
-      const { getByTestId } = render(<ResidenceCreationScreen />);
-      
-      const requiredElements = [
-        'residence-name',
-        'email',
-        'website',
-        'next-button'
-      ];
+    it('requires residence name before file upload', async () => {
+      const mockFile = {
+        canceled: false,
+        assets: [{
+          name: 'test.xlsx',
+          uri: 'file:///test.xlsx'
+        }]
+      };
+      (DocumentPicker.getDocumentAsync as jest.Mock).mockResolvedValueOnce(mockFile);
 
-      requiredElements.forEach(elementId => {
-        expect(getByTestId(elementId)).toBeTruthy();
+      const { getByText } = render(<ResidenceCreationScreen />);
+      fireEvent.press(getByText('List of Apartments (.xlsx)'));
+
+      await waitFor(() => {
+        expect(Alert.alert).toHaveBeenCalledWith(
+          'Error',
+          'Please enter a residence name first'
+        );
       });
     });
   });

--- a/app/screens/landlord/ResidenceCreationScreen.tsx
+++ b/app/screens/landlord/ResidenceCreationScreen.tsx
@@ -212,7 +212,10 @@ function ResidenceCreationScreen() {
 
   return (
     <Header>
-      <ScrollView style={[appStyles.scrollContainer, {paddingBottom: 200}]}>
+      <ScrollView style={[appStyles.scrollContainer, {paddingBottom: 200, paddingHorizontal: 20}]}>
+      <Text testID="screen-title" style={[appStyles.residenceTitle, {marginTop: 20}]}>
+            Create Your Residence
+          </Text>
         <View style={appStyles.formContainer}>
           <CustomTextField
             testID="residence-name"

--- a/app/screens/landlord/ResidenceCreationScreen.tsx
+++ b/app/screens/landlord/ResidenceCreationScreen.tsx
@@ -15,6 +15,7 @@ import Header from '../../components/Header';
 interface ResidenceFormData {
   name: string;
   address: string;
+  number: string;
   zipCode: string;
   city: string;
   provinceState: string;
@@ -74,6 +75,7 @@ function ResidenceCreationScreen() {
   const [formData, setFormData] = useState<ResidenceFormData>({
     name: '',
     address: '',
+    number: '',
     zipCode: '',
     city: '',
     provinceState: '',
@@ -99,7 +101,6 @@ function ResidenceCreationScreen() {
       
       const apartmentNames = rows.slice(1).map(row => row[0]).filter(Boolean);
       setApartments(apartmentNames);
-      console.log('Parsed apartments:', apartmentNames);
       Alert.alert('Success', `Parsed ${apartmentNames.length} apartments`);
     } catch (error) {
       Alert.alert('Error', 'Failed to parse Excel file');
@@ -242,22 +243,30 @@ function ResidenceCreationScreen() {
 
           <View style={appStyles.formRow}>
             <CustomTextField
-              testID="zip-code"
-              value={formData.zipCode}
-              onChangeText={handleChange('zipCode')}
-              placeholder="Zip Code"
+              testID="number"
+              value={formData.number}
+              onChangeText={handleChange('number')}
+              placeholder="Street no"
               style={appStyles.formZipCode}
               keyboardType="numeric"
             />
 
             <CustomTextField
-              testID="city"
-              value={formData.city}
-              onChangeText={handleChange('city')}
-              placeholder="City"
-              style={appStyles.formCity}
+              testID="zip-code"
+              value={formData.zipCode}
+              onChangeText={handleChange('zipCode')}
+              placeholder="Zip Code"
+              style={appStyles.formZipCode}
             />
           </View>
+
+          <CustomTextField
+            testID="city"
+            value={formData.city}
+            onChangeText={handleChange('city')}
+            placeholder="City"
+            style={appStyles.formFullWidth}
+          />
 
           <CustomTextField
             testID="province-state"

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
       "^.+\\.(js|jsx|ts|tsx)$": "babel-jest"
     },
     "transformIgnorePatterns": [
-"node_modules/(?!(@react-native|react-native-parsed-text|react-native-vector-icons|react-native|@react-navigation|react-native-reanimated|react-native-gesture-handler|expo-modules-core|expo|@expo/vector-icons|@react-native/polyfills|@firebase|firebase|react-native-elements|react-native-size-matters|react-native-ratings|react-native-gifted-chat|uuid|react-native-get-random-values|@react-native-firebase|react-native-feather|@react-native-async-storage|expo-linear-gradient|react-native-timer-picker|react-native-picker-select|@react-native-picker/picker)/)"
+      "node_modules/(?!(@react-native|react-native-parsed-text|react-native-vector-icons|react-native|@react-navigation|react-native-reanimated|react-native-gesture-handler|expo-modules-core|expo|@expo/vector-icons|@react-native/polyfills|@firebase|firebase|react-native-elements|react-native-size-matters|react-native-ratings|react-native-gifted-chat|uuid|react-native-get-random-values|@react-native-firebase|react-native-feather|@react-native-async-storage|expo-linear-gradient|react-native-timer-picker|react-native-picker-select|@react-native-picker/picker)/)"
     ],
     "testRegex": "(/__tests__/.*|(\\.|/)(test|spec))\\.[jt]sx?$",
     "moduleFileExtensions": [

--- a/styles/styles.ts
+++ b/styles/styles.ts
@@ -496,7 +496,7 @@ export const appStyles = StyleSheet.create({
   addResidenceButton: {
     zIndex: 2,
     position: 'absolute',
-    bottom: '35%',
+    bottom: '10%',
     right: 24,
     width: 56,
     height: 56,


### PR DESCRIPTION
# Add Street Number Field to the ResidenceCreationScreen

While working on my weekly task, I noticed the `streetNumber` field in the `Residence` type. Since the **Figma design** for the `ResidenceCreationScreen` did not include the street number of the address, I decided to:

1. Add it to the **Figma mockup**.
2. Implement the corresponding changes in the UI.

### Design Tweak Proposal
![Screenshot from 2024-12-04 18-01-44](https://github.com/user-attachments/assets/8d5a5755-61b5-483e-9784-21e1c3a39272)  
![Screenshot from 2024-12-04 18-02-05](https://github.com/user-attachments/assets/a683788a-439a-4f88-8cab-d1886f8a974e)

### Changes Made
- **Rearranged the layout**:
  - Moved the `City` field below the `Zip Code` field.
  - Used the remaining space in the row to include the `Street Number` field.
- This change ensures:
  - A cleaner, more visually appealing layout.
  - Avoids having three elements in a single row, which was aesthetically unpleasing.

### Implementation
- Updated the Figma design to reflect the proposed changes.
- Implemented the new layout in the UI code, ensuring the `streetNumber` field is correctly handled.
