### PR TITLE
hotfix: Washing machines screen and manage washing machine : refracto…

### DIFF
--- a/app/Navigators/LandlordDrawerNavigator.tsx
+++ b/app/Navigators/LandlordDrawerNavigator.tsx
@@ -34,7 +34,6 @@ const LandlordDrawerNavigator = () => {
         <Drawer.Screen name='Dashboard' component={IssueStackLandlord} />
         <Drawer.Screen name='List Issues' component={LandlordListIssuesScreen} />
         <Drawer.Screen name='Manage Machines' component={ManageMachinesScreen} />
-        <Drawer.Screen name='Washing Machine' component={WashingMachineScreen} />
         <Drawer.Screen name='Residence Stack' component={ResidenceStack} />
         <Drawer.Screen
           name='Situation Report Creation'

--- a/app/__tests__/LandlordDrawerNavigator.test.tsx
+++ b/app/__tests__/LandlordDrawerNavigator.test.tsx
@@ -78,7 +78,6 @@ describe('LandlordDrawerNavigator', () => {
       'Dashboard',
       'List Issues',
       'Manage Machines',
-      'Washing Machine',
       'Residence Stack',
       'Situation Report Creation',
       'Situation Report Form',

--- a/app/__tests__/ManageMachinesScreen.test.tsx
+++ b/app/__tests__/ManageMachinesScreen.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, fireEvent, waitFor } from '@testing-library/react-native';
+import { render, fireEvent, waitFor, act } from '@testing-library/react-native';
 import { NavigationContainer } from '@react-navigation/native';
 import ManageMachinesScreen from '../screens/laundry_machines/ManageMachinesScreen';
 import * as firestoreModule from '../../firebase/firestore/firestore';
@@ -7,6 +7,7 @@ import { getFirestore } from 'firebase/firestore';
 import { Timestamp } from 'firebase/firestore';
 import { getAuth, initializeAuth, getReactNativePersistence } from 'firebase/auth';
 import { initializeApp } from 'firebase/app';
+import { AuthProvider } from '../context/AuthContext';
 
 jest.mock('firebase/app', () => ({
   initializeApp: jest.fn(),
@@ -48,13 +49,35 @@ const mockFirestore = firestoreModule as jest.Mocked<typeof firestoreModule>;
 
 const renderWithNavigation = (component: React.ReactElement) => {
   return render(
-    <NavigationContainer>
-      {component}
-    </NavigationContainer>
+    <AuthProvider 
+      firebaseUser={null}
+      fetchUser={jest.fn()}
+      fetchTenant={jest.fn()}
+      fetchLandlord={jest.fn()}
+    >
+      <NavigationContainer>
+        {component}
+      </NavigationContainer>
+    </AuthProvider>
   );
 };
 
 describe('ManageMachinesScreen', () => {
+  const mockUser = {
+    uid: 'testUid',
+    email: 'test@example.com'
+  };
+
+  const mockLandlord = {
+    uid: 'testUid',
+    residenceIds: ['residence1'],
+  };
+
+  const mockResidence = {
+    residenceId: 'residence1',
+    residenceName: 'Test Residence',
+  };
+
   const mockMachines = [
     {
       laundryMachineId: 'machine1',
@@ -67,21 +90,20 @@ describe('ManageMachinesScreen', () => {
     },
   ];
 
-  beforeAll(() => {
-    (getFirestore as jest.Mock).mockReturnValue({});
-    (getAuth as jest.Mock).mockReturnValue({});
-    (initializeApp as jest.Mock).mockReturnValue({
-      name: '[DEFAULT]',
-      options: {},
-    });
-  });
-
   beforeEach(() => {
     jest.clearAllMocks();
     mockFirestore.getAllLaundryMachines.mockResolvedValue(mockMachines);
+    mockFirestore.getLandlord.mockResolvedValue(mockLandlord);
+    mockFirestore.getResidence.mockResolvedValue(mockResidence);
     mockFirestore.createLaundryMachine.mockResolvedValue(undefined);
     mockFirestore.deleteLaundryMachine.mockResolvedValue(undefined);
     mockFirestore.updateLaundryMachine.mockResolvedValue(undefined);
+    
+    jest.spyOn(require('../context/AuthContext'), 'useAuth').mockImplementation(() => ({
+      user: mockUser,
+      loading: false,
+      error: null,
+    }));
   });
 
   it('renders correctly with initial machines', async () => {
@@ -94,24 +116,53 @@ describe('ManageMachinesScreen', () => {
 
   it('adds a new machine successfully', async () => {
     const { getByPlaceholderText, getByText } = renderWithNavigation(<ManageMachinesScreen />);
+    
+    await waitFor(() => {
+      expect(getByText('Test Residence')).toBeTruthy();
+    });
+
     const input = getByPlaceholderText('Enter Machine ID');
     fireEvent.changeText(input, 'newMachine');
+    
     const addButton = getByText('Add Machine');
-    fireEvent.press(addButton);
+    await act(async () => {
+      fireEvent.press(addButton);
+    });
 
     await waitFor(() => {
-      expect(mockFirestore.createLaundryMachine).toHaveBeenCalled();
+      expect(mockFirestore.createLaundryMachine).toHaveBeenCalledWith(
+        'residence1',
+        expect.objectContaining({
+          laundryMachineId: 'newMachine',
+          isAvailable: true,
+          isFunctional: true,
+          occupiedBy: 'none',
+          notificationScheduled: false,
+        })
+      );
     });
   });
 
   it('shows error when adding duplicate machine ID', async () => {
-    const { getByPlaceholderText, getByText } = renderWithNavigation(<ManageMachinesScreen />);
-    await waitFor(() => {});
+    const { getByPlaceholderText, getByText, findByText } = renderWithNavigation(<ManageMachinesScreen />);
+    
+    await waitFor(() => {
+      expect(getByText('Test Residence')).toBeTruthy();
+    });
+
+    mockFirestore.createLaundryMachine.mockRejectedValueOnce(new Error('Machine ID already exists'));
+
     const input = getByPlaceholderText('Enter Machine ID');
     fireEvent.changeText(input, 'machine1');
+    
     const addButton = getByText('Add Machine');
-    fireEvent.press(addButton);
-    expect(getByText('A machine with this ID already exists.')).toBeTruthy();
+    await act(async () => {
+      fireEvent.press(addButton);
+    });
+
+    await waitFor(() => {
+      expect(getByText('Failed to add machine. Please try again.')).toBeTruthy();
+    });
   });
 
   it('deletes a machine successfully', async () => {
@@ -121,7 +172,7 @@ describe('ManageMachinesScreen', () => {
     fireEvent.press(deleteButton);
 
     await waitFor(() => {
-      expect(mockFirestore.deleteLaundryMachine).toHaveBeenCalledWith('TestResidence1', 'machine1');
+      expect(mockFirestore.deleteLaundryMachine).toHaveBeenCalledWith('residence1', 'machine1');
     });
   });
 
@@ -133,7 +184,7 @@ describe('ManageMachinesScreen', () => {
 
     await waitFor(() => {
       expect(mockFirestore.updateLaundryMachine).toHaveBeenCalledWith(
-        'TestResidence1',
+        'residence1',
         'machine1',
         { isFunctional: false }
       );
@@ -153,19 +204,36 @@ describe('ManageMachinesScreen', () => {
   it('fetches machines on mount', async () => {
     renderWithNavigation(<ManageMachinesScreen />);
     await waitFor(() => {
-      expect(mockFirestore.getAllLaundryMachines).toHaveBeenCalledWith('TestResidence1');
+      expect(mockFirestore.getAllLaundryMachines).toHaveBeenCalledWith('residence1');
     });
   });
 
   it('updates machine list after adding new machine', async () => {
     const { getByPlaceholderText, getByText, findByText } = renderWithNavigation(<ManageMachinesScreen />);
-    const input = getByPlaceholderText('Enter Machine ID');
-    fireEvent.changeText(input, 'newMachine');
-    fireEvent.press(getByText('Add Machine'));
     
     await waitFor(() => {
-      expect(mockFirestore.createLaundryMachine).toHaveBeenCalled();
+      expect(getByText('Test Residence')).toBeTruthy();
     });
+
+    const input = getByPlaceholderText('Enter Machine ID');
+    fireEvent.changeText(input, 'newMachine');
+    
+    const updatedMachines = [...mockMachines, {
+      laundryMachineId: 'newMachine',
+      isAvailable: true,
+      isFunctional: true,
+      occupiedBy: 'none',
+      startTime: Timestamp.fromMillis(Date.now()),
+      estimatedFinishTime: Timestamp.fromMillis(Date.now()),
+      notificationScheduled: false,
+    }];
+    mockFirestore.getAllLaundryMachines.mockResolvedValueOnce(updatedMachines);
+
+    const addButton = getByText('Add Machine');
+    await act(async () => {
+      fireEvent.press(addButton);
+    });
+
     await findByText('Washing machine newMachine');
   });
 

--- a/app/__tests__/WashingMachineScreen.test.tsx
+++ b/app/__tests__/WashingMachineScreen.test.tsx
@@ -1,31 +1,52 @@
 import React from 'react';
-import { render, fireEvent, waitFor, screen, act } from '@testing-library/react-native';
+import {
+  render,
+  fireEvent,
+  waitFor,
+  screen,
+  act,
+} from '@testing-library/react-native';
 import { NavigationContainer } from '@react-navigation/native';
 import WashingMachineScreen from '../screens/laundry_machines/WashingMachineScreen';
-import { getLaundryMachine, updateLaundryMachine } from '../../firebase/firestore/firestore';
+import {
+  getLaundryMachine,
+  getTenant,
+  updateLaundryMachine,
+} from '../../firebase/firestore/firestore';
 import { getAuth } from 'firebase/auth';
-import { onSnapshot } from 'firebase/firestore';
-import * as Notifications from "expo-notifications";
-import { NotificationPermissionsStatus } from "expo-notifications";
+import { onSnapshot, Timestamp } from 'firebase/firestore';
+import * as Notifications from 'expo-notifications';
+import { NotificationPermissionsStatus } from 'expo-notifications';
+import { LaundryMachine } from '../../types/types';
+// Import the mocked functions
+import {
+  getLaundryMachinesQuery,
+  createMachineNotification,
+} from '../../firebase/firestore/firestore';
 
 // Mock expo-linear-gradient
 jest.mock('expo-linear-gradient', () => ({
   LinearGradient: ({ children }: { children: React.ReactNode }) => children,
 }));
 
-  // Mock expo-notifications
-  jest.mock("expo-notifications", () => ({
-    getPermissionsAsync: jest.fn(),
-    requestPermissionsAsync: jest.fn(),
-    scheduleNotificationAsync: jest.fn(),
-    setNotificationHandler: jest.fn(() => {}),
-  }));
+// Mock expo-notifications
+jest.mock('expo-notifications', () => ({
+  getPermissionsAsync: jest.fn(),
+  requestPermissionsAsync: jest.fn(),
+  scheduleNotificationAsync: jest.fn(),
+  setNotificationHandler: jest.fn(() => {}),
+}));
 
 jest.mock('../../firebase/firestore/firestore', () => ({
   getLaundryMachine: jest.fn(),
   updateLaundryMachine: jest.fn(),
   getLaundryMachinesQuery: jest.fn(),
   createMachineNotification: jest.fn(),
+  getTenant: jest.fn(() =>
+    Promise.resolve({
+      residenceId: 'TestResidence1',
+    }),
+  ),
 }));
 
 jest.mock('firebase/auth', () => ({
@@ -52,38 +73,127 @@ jest.mock('firebase/firestore', () => ({
 // Mock clearInterval globally
 global.clearInterval = jest.fn();
 
-// Import the mocked functions
-import { 
-  getLaundryMachinesQuery,
-  createMachineNotification 
-} from '../../firebase/firestore/firestore';
-
-const renderWithNavigation = (ui: React.ReactElement) => {
-  return render(
-    <NavigationContainer>{ui}</NavigationContainer>
-  );
+// Move this helper function before renderWithNavigation
+const waitForAsync = async () => {
+  await act(async () => {
+    await Promise.resolve();
+    jest.runAllTimers();
+  });
 };
 
+const renderWithNavigation = async (component: React.ReactElement) => {
+  const rendered = render(
+    <NavigationContainer>{component}</NavigationContainer>,
+  );
+
+  await waitForAsync();
+  return rendered;
+};
+
+declare global {
+  interface Global {
+    alert?: (message?: any) => void;
+  }
+}
+
+async function mountComponentWithMachine(machineData: Partial<LaundryMachine>) {
+  const mockMachine = {
+    laundryMachineId: 'machine1',
+    isAvailable: true,
+    isFunctional: true,
+    occupiedBy: 'none',
+    ...machineData,
+  };
+
+  const mockQuerySnapshot = {
+    forEach: (callback: any) =>
+      callback({ id: 'machine1', data: () => mockMachine }),
+    docs: [{ id: 'machine1', data: () => mockMachine }],
+    empty: false,
+    size: 1,
+  };
+
+  (onSnapshot as jest.Mock).mockImplementation((query, callback) => {
+    act(() => {
+      callback(mockQuerySnapshot);
+    });
+    return () => {};
+  });
+
+  const rendered = await renderWithNavigation(<WashingMachineScreen />);
+
+  // Wait for initial mount and data fetch
+  await act(async () => {
+    await waitForAsync();
+  });
+
+  return rendered;
+}
+
+async function setupTimerTest() {
+  // Mock timing functions
+  jest.useFakeTimers();
+  const currentTime = Date.now();
+  jest.setSystemTime(currentTime);
+
+  // Mock notification permissions
+  (Notifications.getPermissionsAsync as jest.Mock).mockResolvedValue({
+    status: 'granted',
+  } as NotificationPermissionsStatus);
+
+  // Mock notification scheduling
+  (Notifications.scheduleNotificationAsync as jest.Mock).mockResolvedValue(
+    'notification-id-1',
+  );
+
+  const machine = {
+    laundryMachineId: 'machine1',
+    isAvailable: true,
+    isFunctional: true,
+    occupiedBy: 'none',
+    startTime: Timestamp.now(),
+    estimatedFinishTime: Timestamp.fromMillis(currentTime + 5000000), // Far in the future
+  };
+
+  return { machine, currentTime };
+}
 describe('WashingMachineScreen', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    jest.useFakeTimers();
+    // Mock window.alert since it's not available in the test environment
+    global.alert = jest.fn();
+    // Mock getTenant to return a residenceId consistently
+    (getTenant as jest.Mock).mockResolvedValue({
+      residenceId: 'TestResidence1',
+    });
+    // Mock getLaundryMachinesQuery to prevent "Failed to fetch" errors
+    (getLaundryMachinesQuery as jest.Mock).mockReturnValue({});
   });
 
-  it('renders empty state correctly', () => {
-    const { getByText } = renderWithNavigation(<WashingMachineScreen />);
+  afterEach(() => {
+    jest.clearAllTimers();
+    jest.clearAllMocks();
+    global.alert = () => {};
+  });
+
+  it('renders empty state correctly', async () => {
+    const { getByText } = await renderWithNavigation(<WashingMachineScreen />);
     expect(getByText('No washing machines available')).toBeTruthy();
   });
 
   it('handles refresh control', async () => {
-    const { getByTestId } = renderWithNavigation(<WashingMachineScreen />);
+    const { getByTestId } = await renderWithNavigation(
+      <WashingMachineScreen />,
+    );
     const scrollView = getByTestId('scroll-view');
-    
+
     fireEvent.scroll(scrollView, {
       nativeEvent: {
         contentOffset: { y: 0 },
         contentSize: { height: 600, width: 400 },
-        layoutMeasurement: { height: 400, width: 400 }
-      }
+        layoutMeasurement: { height: 400, width: 400 },
+      },
     });
   });
 
@@ -92,32 +202,47 @@ describe('WashingMachineScreen', () => {
       laundryMachineId: 'machine1',
       isAvailable: true,
       isFunctional: true,
-      occupiedBy: 'none'
+      occupiedBy: 'none',
     };
-    
+
     const mockDoc = {
       id: 'machine1',
-      data: () => mockMachine
+      data: () => mockMachine,
     };
-    
+
     const mockQuerySnapshot = {
-      forEach: (callback: (arg0: { id: string; data: () => { laundryMachineId: string; isAvailable: boolean; isFunctional: boolean; occupiedBy: string; }; }) => any) => callback(mockDoc),
+      forEach: (
+        callback: (arg0: {
+          id: string;
+          data: () => {
+            laundryMachineId: string;
+            isAvailable: boolean;
+            isFunctional: boolean;
+            occupiedBy: string;
+          };
+        }) => any,
+      ) => callback(mockDoc),
       docs: [mockDoc],
       empty: false,
-      size: 1
+      size: 1,
     };
-    
+
     (onSnapshot as jest.Mock).mockImplementation((query, callback) => {
       setTimeout(() => callback(mockQuerySnapshot), 0);
       return () => {};
     });
 
-    const { getByText, getByTestId } = renderWithNavigation(<WashingMachineScreen />);
-    
-    await waitFor(() => {
-      expect(getByText('Machine machine1')).toBeTruthy();
-    }, { timeout: 3000 });
-    
+    const { getByText, getByTestId } = await renderWithNavigation(
+      <WashingMachineScreen />,
+    );
+
+    await waitFor(
+      () => {
+        expect(getByText('Machine machine1')).toBeTruthy();
+      },
+      { timeout: 3000 },
+    );
+
     expect(getByTestId('setTimerButton')).toBeTruthy();
   });
 
@@ -126,81 +251,46 @@ describe('WashingMachineScreen', () => {
       laundryMachineId: 'machine1',
       isAvailable: true,
       isFunctional: false,
-      occupiedBy: 'none'
+      occupiedBy: 'none',
     };
-    
+
     const mockQuerySnapshot = {
-      forEach: (callback: (arg0: { data: () => { laundryMachineId: string; isAvailable: boolean; isFunctional: boolean; occupiedBy: string; }; }) => any) => callback({
-        data: () => mockMachine
-      })
+      forEach: (
+        callback: (arg0: {
+          data: () => {
+            laundryMachineId: string;
+            isAvailable: boolean;
+            isFunctional: boolean;
+            occupiedBy: string;
+          };
+        }) => any,
+      ) =>
+        callback({
+          data: () => mockMachine,
+        }),
     };
-    
+
     (onSnapshot as jest.Mock).mockImplementation((query, callback) => {
       callback(mockQuerySnapshot);
       return () => {};
     });
 
-    const { getByText } = renderWithNavigation(<WashingMachineScreen />);
-    
+    const { getByText } = await renderWithNavigation(<WashingMachineScreen />);
+
     await waitFor(() => {
       expect(getByText('Under Maintenance')).toBeTruthy();
     });
   });
 
-  it('handles machine reset', async () => {
-    const mockMachine = {
-      laundryMachineId: 'machine1',
-      isAvailable: false,
-      isFunctional: true,
-      occupiedBy: 'test-user-id',
-      estimatedFinishTime: {
-        toMillis: () => Date.now() + 1000
-      }
-    };
-    
-    const mockDoc = {
-      id: 'machine1',
-      data: () => mockMachine
-    };
-    
-    const mockQuerySnapshot = {
-      forEach: (callback: (arg0: { id: string; data: () => { laundryMachineId: string; isAvailable: boolean; isFunctional: boolean; occupiedBy: string; estimatedFinishTime: { toMillis: () => number; }; }; }) => any) => callback(mockDoc),
-      docs: [mockDoc],
-      empty: false,
-      size: 1
-    };
-    
-    (onSnapshot as jest.Mock).mockImplementation((query, callback) => {
-      setTimeout(() => callback(mockQuerySnapshot), 0);
-      return () => {};
-    });
-
-    const { getByTestId } = renderWithNavigation(<WashingMachineScreen />);
-    
-    await waitFor(() => {
-      const unlockButton = getByTestId('unlockButton');
-      fireEvent.press(unlockButton);
-    }, { timeout: 3000 });
-
-    expect(updateLaundryMachine).toHaveBeenCalledWith(
-      'TestResidence1',
-      'machine1',
-      expect.objectContaining({
-        isAvailable: true,
-        occupiedBy: 'none'
-      })
-    );
-  });
-
   it('handles error in fetching machines', async () => {
     const consoleSpy = jest.spyOn(console, 'error').mockImplementation();
-    
+
     (getLaundryMachinesQuery as jest.Mock).mockImplementation(() => {
       throw new Error('Failed to fetch');
     });
 
-    const { getByText } = renderWithNavigation(<WashingMachineScreen />);
-    
+    const { getByText } = await renderWithNavigation(<WashingMachineScreen />);
+
     await waitFor(() => {
       expect(getByText('No washing machines available')).toBeTruthy();
       expect(consoleSpy).toHaveBeenCalled();
@@ -209,188 +299,75 @@ describe('WashingMachineScreen', () => {
     consoleSpy.mockRestore();
   });
 
-  it('updates remaining time display', async () => {
-    jest.useFakeTimers();
-    
-    // Set up a well-defined timeline
-    const startTime = 1000000;
-    const duration = 60000; // 1 minute
-    jest.setSystemTime(startTime);
-    
-    // Mock granted permissions
-    (Notifications.getPermissionsAsync as jest.Mock).mockResolvedValueOnce({
-      status: "granted",
-    } as NotificationPermissionsStatus);
-
-    const mockMachine = {
-      laundryMachineId: 'machine1',
-      isAvailable: false,
-      isFunctional: true,
-      occupiedBy: 'test-user-id',
-      estimatedFinishTime: {
-        toMillis: () => startTime + duration // Will finish in 1 minute
-      },
-      startTime: {
-        toMillis: () => startTime
-      },
-      notificationScheduled: false
-    };
-    
-    const mockQuerySnapshot = {
-      forEach: jest.fn((callback) => {
-        callback({
-          id: 'machine1',
-          data: () => ({ ...mockMachine })
-        });
-      }),
-      empty: false,
-      size: 1
-    };
-  
-    (getLaundryMachinesQuery as jest.Mock).mockReturnValue({});
-  
-    (onSnapshot as jest.Mock).mockImplementation((query: any, callback: (arg0: { forEach: jest.Mock<void, [callback: any], any>; empty: boolean; size: number; }) => void) => {
-      callback(mockQuerySnapshot);
-      return () => {};
-    });
-    const { getByText } = render(
-      <NavigationContainer>
-        <WashingMachineScreen />
-      </NavigationContainer>
+  it('handles refresh control pull-to-refresh', async () => {
+    const { getByTestId } = await renderWithNavigation(
+      <WashingMachineScreen />,
     );
-  
-    // Run initial timers
-    act(() => {
-      jest.runOnlyPendingTimers();
-    });
-  
-    // Verify machine is rendered
-    expect(getByText('Machine machine1')).toBeTruthy();
-  
-    // Check for the initial timer display (should be close to 1 minute)
-    // Use a more flexible regex that accounts for the full range of possible values
-    await waitFor(
-      () => {
-        expect(getByText(/0h \d+m \d+s/)).toBeTruthy();
-      },
-      { timeout: 3000 } // Wait for 3 seconds
-    );  
-    // Advance halfway through
-    act(() => {
-      jest.advanceTimersByTime(30000); // Advance 30 seconds
+
+    await waitForAsync();
+
+    const scrollView = getByTestId('scroll-view');
+    await act(async () => {
+      fireEvent(scrollView, 'refresh');
     });
 
-    // Check timer after advancing (should be around 30 seconds)
-    await waitFor(
-      () => {
-        expect(getByText(/0h \d+m \d+s/)).toBeTruthy();
-      },
-      { timeout: 3000 } // Wait for 3 seconds
-    );
-  
-    jest.useRealTimers();
+    await waitForAsync();
+
+    expect(getLaundryMachinesQuery).toHaveBeenCalledWith('TestResidence1');
   });
 
-  it('handles timer cancellation', async () => {
-    const mockMachine = {
+  // Test status display (lines 331-333)
+  it('displays correct machine status', async () => {
+    // Test maintenance status
+    const maintenanceMachine = {
+      laundryMachineId: 'machine1',
+      isAvailable: true,
+      isFunctional: false,
+      occupiedBy: 'none',
+    };
+    
+    const { getByText: getByText1 } = await mountComponentWithMachine(maintenanceMachine);
+    expect(getByText1('Under Maintenance')).toBeTruthy();
+
+    // Test in-use status
+    const inUseMachine = {
       laundryMachineId: 'machine1',
       isAvailable: false,
       isFunctional: true,
-      occupiedBy: 'test-user-id',
-      estimatedFinishTime: {
-        toMillis: () => Date.now() + 1000000 // Some time in the future
-      }
+      occupiedBy: 'some-user',
     };
     
-    const mockDoc = {
-      id: 'machine1',
-      data: () => mockMachine
-    };
-    
-    const mockQuerySnapshot = {
-      forEach: (callback: (arg0: {
-              id: string; data: () => {
-                  laundryMachineId: string; isAvailable: boolean; isFunctional: boolean; occupiedBy: string; estimatedFinishTime: {
-                      toMillis: () => number; // Some time in the future
-                  };
-              };
-          }) => any) => callback(mockDoc),
-      docs: [mockDoc],
-      empty: false,
-      size: 1
-    };
-    
-    (onSnapshot as jest.Mock).mockImplementation((query, callback) => {
-      setTimeout(() => callback(mockQuerySnapshot), 0);
-      return () => {};
+    const { getByText: getByText2 } = await mountComponentWithMachine(inUseMachine);
+    expect(getByText2('In Use')).toBeTruthy();
+  });
+
+  // Test timer modal interactions (lines 397-441)
+  it('handles timer modal interactions', async () => {
+    const { machine } = await setupTimerTest();
+    const { getByTestId, getByText } = await mountComponentWithMachine(machine);
+
+    // Open timer modal
+    await act(async () => {
+      const setTimerButton = getByTestId('setTimerButton');
+      fireEvent.press(setTimerButton);
+      await waitForAsync();
     });
 
-    const { getByTestId } = renderWithNavigation(<WashingMachineScreen />);
-    
-    await waitFor(() => {
-      const cancelButton = getByTestId('cancelTimerButton');
-      fireEvent.press(cancelButton);
+    // Select duration and confirm
+    await act(async () => {
+      const confirmButton = getByText('Confirm');
+      fireEvent.press(confirmButton);
+      await waitForAsync();
     });
 
     expect(updateLaundryMachine).toHaveBeenCalledWith(
       'TestResidence1',
       'machine1',
       expect.objectContaining({
-        isAvailable: true,
-        occupiedBy: 'none'
+        isAvailable: false,
+        occupiedBy: 'test-user-id',
       })
     );
   });
 
-  it('handles timer setting', async () => {
-    const mockMachine = {
-      laundryMachineId: 'machine1',
-      isAvailable: true,
-      isFunctional: true,
-      occupiedBy: 'none'
-    };
-    
-    const mockDoc = {
-      id: 'machine1',
-      data: () => mockMachine
-    };
-    
-    const mockQuerySnapshot = {
-      forEach: (callback: (arg0: { id: string; data: () => { laundryMachineId: string; isAvailable: boolean; isFunctional: boolean; occupiedBy: string; }; }) => any) => callback(mockDoc),
-      docs: [mockDoc],
-      empty: false,
-      size: 1
-    };
-    
-    (onSnapshot as jest.Mock).mockImplementation((query, callback) => {
-      setTimeout(() => callback(mockQuerySnapshot), 0);
-      return () => {};
-    });
-
-    const { getByTestId } = renderWithNavigation(<WashingMachineScreen />);
-    
-    await waitFor(() => {
-      const setTimerButton = getByTestId('setTimerButton');
-      fireEvent.press(setTimerButton);
-    });
-
-    // Verify timer modal becomes visible
-    expect(screen.getByText('Choose Washing Duration')).toBeTruthy();
-  });
-
-  it('handles refresh control pull-to-refresh', async () => {
-    const { getByTestId } = renderWithNavigation(<WashingMachineScreen />);
-    const scrollView = getByTestId('scroll-view');
-    
-    fireEvent.scroll(scrollView, {
-      nativeEvent: {
-        contentOffset: { y: -100 }, // Pulling down
-        contentSize: { height: 600, width: 400 },
-        layoutMeasurement: { height: 400, width: 400 }
-      }
-    });
-
-    // Verify that fetchMachines was called
-    expect(getLaundryMachinesQuery).toHaveBeenCalledWith('TestResidence1');
-  });
 });

--- a/app/screens/auth/LandlordFormScreen.tsx
+++ b/app/screens/auth/LandlordFormScreen.tsx
@@ -203,7 +203,7 @@ const styles = StyleSheet.create({
     justifyContent: "space-between",
   },
   inputField: {
-    backgroundColor: Color.HeaderBackground, // Adjusted for soft purple
+    backgroundColor: Color.TextInputBackground, // Adjusted for soft purple
     borderRadius: 100,
     paddingHorizontal: 10,
     height: 40,


### PR DESCRIPTION
I’ve refactored and fixed various issues related to the Washing Machines screen and the Manage Machines screen. This includes improving navigation, enhancing the user interface, and refining how machines are displayed and managed. I also updated the associated tests to ensure everything behaves correctly.

## Changes

- **Navigation Updates:**  
  - Removed the redundant "Washing Machine" screen entry in the `LandlordDrawerNavigator`.
  - Ensured that the residence stacks and dashboard items are displayed consistently.

- **Manage Machines Screen Improvements:**  
  - Added a residence selector so landlords can switch between their different residences and see the machines of it.
  - Implemented proper error handling and clearer user feedback messages.
  - Ensured that adding, deleting, and updating machines now properly refreshes the list and are actually added and deleted on the database according to the Laundry Machine list of a residenceID

- **Washing Machine Screen Enhancements:**  
  - Fixed timer features and improved the layout for better readability.
  - Updated the logic to handle tenant residence fetching correctly.
  - Improved the pull-to-refresh feature for fetching the latest machine data.
  
- **LandlordProfileScreen**: 
   - Refractored the style to have the same background of the input field as the other component like this in the app 

- **Testing Overhaul:**  
  - Refactored old test which took most of my time 
  
  
<img width="374" alt="image" src="https://github.com/user-attachments/assets/fcf2da9f-c1e8-480a-a52b-b7b8c8590828" />

  
<img width="376" alt="Screenshot 2024-12-20 at 01 59 49" src="https://github.com/user-attachments/assets/a8e77ffd-1b5c-4d3f-92eb-80af64a27a4e" />


